### PR TITLE
GPX Export und Suchgebiet Editierung

### DIFF
--- a/src/Einsatzueberwachung.Domain/Interfaces/IEinsatzService.cs
+++ b/src/Einsatzueberwachung.Domain/Interfaces/IEinsatzService.cs
@@ -57,6 +57,11 @@ namespace Einsatzueberwachung.Domain.Interfaces
         Task SetElwPositionAsync(double latitude, double longitude);
         Task ClearElwPositionAsync();
 
+        // Koordinaten-Marker (Punkte auf der Karte)
+        Task<MapMarker> AddMapMarkerAsync(MapMarker marker);
+        Task RemoveMapMarkerAsync(string markerId);
+        Task<List<MapMarker>> GetMapMarkersAsync();
+
         EinsatzRuntimeSnapshot ExportRuntimeSnapshot();
         Task ImportRuntimeSnapshotAsync(EinsatzRuntimeSnapshot snapshot);
         

--- a/src/Einsatzueberwachung.Domain/Interfaces/IEinsatzService.cs
+++ b/src/Einsatzueberwachung.Domain/Interfaces/IEinsatzService.cs
@@ -59,6 +59,7 @@ namespace Einsatzueberwachung.Domain.Interfaces
 
         // Koordinaten-Marker (Punkte auf der Karte)
         Task<MapMarker> AddMapMarkerAsync(MapMarker marker);
+        Task<MapMarker?> UpdateMapMarkerAsync(string markerId, string? label = null, double? latitude = null, double? longitude = null);
         Task RemoveMapMarkerAsync(string markerId);
         Task<List<MapMarker>> GetMapMarkersAsync();
 

--- a/src/Einsatzueberwachung.Domain/Models/EinsatzData.cs
+++ b/src/Einsatzueberwachung.Domain/Models/EinsatzData.cs
@@ -30,6 +30,7 @@ namespace Einsatzueberwachung.Domain.Models
 
         public List<GlobalNotesEntry> GlobalNotesEntries { get; set; }
         public List<SearchArea> SearchAreas { get; set; }
+        public List<MapMarker> MapMarkers { get; set; }
         public List<Team> Teams { get; set; }
 
         public (double Latitude, double Longitude)? ElwPosition { get; set; }
@@ -63,6 +64,7 @@ namespace Einsatzueberwachung.Domain.Models
             AlarmierungsZeit = null;
             GlobalNotesEntries = new List<GlobalNotesEntry>();
             SearchAreas = new List<SearchArea>();
+            MapMarkers = new List<MapMarker>();
             Teams = new List<Team>();
             ElwPosition = null;
             TrackSnapshots = new List<TeamTrackSnapshot>();

--- a/src/Einsatzueberwachung.Domain/Models/MapMarker.cs
+++ b/src/Einsatzueberwachung.Domain/Models/MapMarker.cs
@@ -1,0 +1,49 @@
+// Repräsentiert einen Koordinaten-Marker auf der Karte
+// Kann per Mausklick oder durch Eingabe von Dezimal-/UTM-Koordinaten erstellt werden
+
+using System;
+
+namespace Einsatzueberwachung.Domain.Models
+{
+    public class MapMarker
+    {
+        public string Id { get; set; }
+        public string Label { get; set; }
+        public string Description { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public string Color { get; set; }
+        public DateTime CreatedAt { get; set; }
+        
+        /// <summary>
+        /// UTM-Zone (z.B. "32U"), wird aus Lat/Long berechnet
+        /// </summary>
+        public string UtmZone { get; set; }
+        
+        /// <summary>
+        /// UTM Ostwert (Easting) in Metern
+        /// </summary>
+        public double UtmEasting { get; set; }
+        
+        /// <summary>
+        /// UTM Nordwert (Northing) in Metern
+        /// </summary>
+        public double UtmNorthing { get; set; }
+
+        public MapMarker()
+        {
+            Id = Guid.NewGuid().ToString();
+            Label = string.Empty;
+            Description = string.Empty;
+            Color = "#E74C3C";
+            CreatedAt = DateTime.Now;
+            UtmZone = string.Empty;
+        }
+
+        public string FormattedLatLng => $"{Latitude:F6}° / {Longitude:F6}°";
+        public string FormattedUtm => !string.IsNullOrEmpty(UtmZone)
+            ? $"{UtmZone} {UtmEasting:F0} E / {UtmNorthing:F0} N"
+            : "";
+        public string FormattedTimestamp => CreatedAt.ToString("HH:mm:ss");
+    }
+}

--- a/src/Einsatzueberwachung.Domain/Models/MapMarker.cs
+++ b/src/Einsatzueberwachung.Domain/Models/MapMarker.cs
@@ -35,7 +35,7 @@ namespace Einsatzueberwachung.Domain.Models
             Id = Guid.NewGuid().ToString();
             Label = string.Empty;
             Description = string.Empty;
-            Color = "#E74C3C";
+            Color = "#2196F3";
             CreatedAt = DateTime.Now;
             UtmZone = string.Empty;
         }

--- a/src/Einsatzueberwachung.Domain/Services/EinsatzService.cs
+++ b/src/Einsatzueberwachung.Domain/Services/EinsatzService.cs
@@ -457,6 +457,31 @@ namespace Einsatzueberwachung.Domain.Services
             return Task.FromResult(marker);
         }
 
+        public Task<MapMarker?> UpdateMapMarkerAsync(string markerId, string? label = null, double? latitude = null, double? longitude = null)
+        {
+            var marker = _currentEinsatz.MapMarkers.FirstOrDefault(m => m.Id == markerId);
+            if (marker == null)
+                return Task.FromResult<MapMarker?>(null);
+
+            if (label != null)
+                marker.Label = label;
+
+            if (latitude.HasValue && longitude.HasValue)
+            {
+                marker.Latitude = latitude.Value;
+                marker.Longitude = longitude.Value;
+
+                // UTM neu berechnen
+                var (zone, band, easting, northing) = UtmConverter.LatLongToUtm(latitude.Value, longitude.Value);
+                marker.UtmZone = UtmConverter.FormatUtmZone(zone, band);
+                marker.UtmEasting = easting;
+                marker.UtmNorthing = northing;
+            }
+
+            EinsatzChanged?.Invoke();
+            return Task.FromResult<MapMarker?>(marker);
+        }
+
         public Task RemoveMapMarkerAsync(string markerId)
         {
             var marker = _currentEinsatz.MapMarkers.FirstOrDefault(m => m.Id == markerId);

--- a/src/Einsatzueberwachung.Domain/Services/EinsatzService.cs
+++ b/src/Einsatzueberwachung.Domain/Services/EinsatzService.cs
@@ -441,6 +441,38 @@ namespace Einsatzueberwachung.Domain.Services
             return Task.CompletedTask;
         }
 
+        public Task<MapMarker> AddMapMarkerAsync(MapMarker marker)
+        {
+            // UTM-Koordinaten berechnen falls noch nicht gesetzt
+            if (string.IsNullOrEmpty(marker.UtmZone))
+            {
+                var (zone, band, easting, northing) = UtmConverter.LatLongToUtm(marker.Latitude, marker.Longitude);
+                marker.UtmZone = UtmConverter.FormatUtmZone(zone, band);
+                marker.UtmEasting = easting;
+                marker.UtmNorthing = northing;
+            }
+
+            _currentEinsatz.MapMarkers.Add(marker);
+            EinsatzChanged?.Invoke();
+            return Task.FromResult(marker);
+        }
+
+        public Task RemoveMapMarkerAsync(string markerId)
+        {
+            var marker = _currentEinsatz.MapMarkers.FirstOrDefault(m => m.Id == markerId);
+            if (marker != null)
+            {
+                _currentEinsatz.MapMarkers.Remove(marker);
+                EinsatzChanged?.Invoke();
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task<List<MapMarker>> GetMapMarkersAsync()
+        {
+            return Task.FromResult(_currentEinsatz.MapMarkers.ToList());
+        }
+
         private void Team_TimerStarted(Team team)
         {
             _ = AddGlobalNoteAsync($"Timer gestartet", GlobalNotesEntryType.TeamStart, team.TeamId);

--- a/src/Einsatzueberwachung.Domain/Services/UtmConverter.cs
+++ b/src/Einsatzueberwachung.Domain/Services/UtmConverter.cs
@@ -8,7 +8,6 @@ namespace Einsatzueberwachung.Domain.Services
     public static class UtmConverter
     {
         private const double A = 6378137.0;           // WGS84 semi-major axis
-        private const double F = 1 / 298.257223563;   // WGS84 flattening
         private const double E = 0.0818191908426;      // WGS84 eccentricity
         private const double E2 = E * E;
         private const double K0 = 0.9996;              // UTM scale factor

--- a/src/Einsatzueberwachung.Domain/Services/UtmConverter.cs
+++ b/src/Einsatzueberwachung.Domain/Services/UtmConverter.cs
@@ -1,0 +1,218 @@
+// UTM (Universal Transverse Mercator) ↔ Lat/Long Konvertierung
+// Basierend auf dem WGS84-Ellipsoid
+
+using System;
+
+namespace Einsatzueberwachung.Domain.Services
+{
+    public static class UtmConverter
+    {
+        private const double A = 6378137.0;           // WGS84 semi-major axis
+        private const double F = 1 / 298.257223563;   // WGS84 flattening
+        private const double E = 0.0818191908426;      // WGS84 eccentricity
+        private const double E2 = E * E;
+        private const double K0 = 0.9996;              // UTM scale factor
+        private const double FalseEasting = 500000.0;
+        private const double FalseNorthingSouth = 10000000.0;
+
+        /// <summary>
+        /// Konvertiert Lat/Long (Dezimalgrad) zu UTM-Koordinaten
+        /// </summary>
+        public static (int Zone, char Band, double Easting, double Northing) LatLongToUtm(double latitude, double longitude)
+        {
+            int zone = (int)Math.Floor((longitude + 180.0) / 6.0) + 1;
+
+            // Sonderregeln für Norwegen und Svalbard
+            if (latitude >= 56 && latitude < 64 && longitude >= 3 && longitude < 12)
+                zone = 32;
+            if (latitude >= 72 && latitude < 84)
+            {
+                if (longitude >= 0 && longitude < 9) zone = 31;
+                else if (longitude >= 9 && longitude < 21) zone = 33;
+                else if (longitude >= 21 && longitude < 33) zone = 35;
+                else if (longitude >= 33 && longitude < 42) zone = 37;
+            }
+
+            char band = GetUtmBand(latitude);
+            double lonOrigin = (zone - 1) * 6 - 180 + 3; // Central meridian
+
+            double latRad = latitude * Math.PI / 180.0;
+            double lonRad = longitude * Math.PI / 180.0;
+            double lonOriginRad = lonOrigin * Math.PI / 180.0;
+
+            double ePrimeSquared = E2 / (1 - E2);
+            double n = A / Math.Sqrt(1 - E2 * Math.Sin(latRad) * Math.Sin(latRad));
+            double t = Math.Tan(latRad) * Math.Tan(latRad);
+            double c = ePrimeSquared * Math.Cos(latRad) * Math.Cos(latRad);
+            double a2 = Math.Cos(latRad) * (lonRad - lonOriginRad);
+
+            double m = A * (
+                (1 - E2 / 4 - 3 * E2 * E2 / 64 - 5 * E2 * E2 * E2 / 256) * latRad
+                - (3 * E2 / 8 + 3 * E2 * E2 / 32 + 45 * E2 * E2 * E2 / 1024) * Math.Sin(2 * latRad)
+                + (15 * E2 * E2 / 256 + 45 * E2 * E2 * E2 / 1024) * Math.Sin(4 * latRad)
+                - (35 * E2 * E2 * E2 / 3072) * Math.Sin(6 * latRad)
+            );
+
+            double easting = K0 * n * (
+                a2
+                + (1 - t + c) * a2 * a2 * a2 / 6
+                + (5 - 18 * t + t * t + 72 * c - 58 * ePrimeSquared) * a2 * a2 * a2 * a2 * a2 / 120
+            ) + FalseEasting;
+
+            double northing = K0 * (
+                m + n * Math.Tan(latRad) * (
+                    a2 * a2 / 2
+                    + (5 - t + 9 * c + 4 * c * c) * a2 * a2 * a2 * a2 / 24
+                    + (61 - 58 * t + t * t + 600 * c - 330 * ePrimeSquared) * a2 * a2 * a2 * a2 * a2 * a2 / 720
+                )
+            );
+
+            if (latitude < 0)
+                northing += FalseNorthingSouth;
+
+            return (zone, band, Math.Round(easting, 2), Math.Round(northing, 2));
+        }
+
+        /// <summary>
+        /// Konvertiert UTM-Koordinaten zu Lat/Long (Dezimalgrad)
+        /// </summary>
+        public static (double Latitude, double Longitude) UtmToLatLong(int zone, char band, double easting, double northing)
+        {
+            bool isNorthern = char.ToUpper(band) >= 'N';
+
+            double x = easting - FalseEasting;
+            double y = isNorthern ? northing : northing - FalseNorthingSouth;
+
+            double lonOrigin = (zone - 1) * 6 - 180 + 3;
+
+            double ePrimeSquared = E2 / (1 - E2);
+            double m = y / K0;
+            double mu = m / (A * (1 - E2 / 4 - 3 * E2 * E2 / 64 - 5 * E2 * E2 * E2 / 256));
+
+            double e1 = (1 - Math.Sqrt(1 - E2)) / (1 + Math.Sqrt(1 - E2));
+            double phi1 = mu
+                + (3 * e1 / 2 - 27 * e1 * e1 * e1 / 32) * Math.Sin(2 * mu)
+                + (21 * e1 * e1 / 16 - 55 * e1 * e1 * e1 * e1 / 32) * Math.Sin(4 * mu)
+                + (151 * e1 * e1 * e1 / 96) * Math.Sin(6 * mu);
+
+            double n1 = A / Math.Sqrt(1 - E2 * Math.Sin(phi1) * Math.Sin(phi1));
+            double t1 = Math.Tan(phi1) * Math.Tan(phi1);
+            double c1 = ePrimeSquared * Math.Cos(phi1) * Math.Cos(phi1);
+            double r1 = A * (1 - E2) / Math.Pow(1 - E2 * Math.Sin(phi1) * Math.Sin(phi1), 1.5);
+            double d = x / (n1 * K0);
+
+            double latitude = phi1 - (n1 * Math.Tan(phi1) / r1) * (
+                d * d / 2
+                - (5 + 3 * t1 + 10 * c1 - 4 * c1 * c1 - 9 * ePrimeSquared) * d * d * d * d / 24
+                + (61 + 90 * t1 + 298 * c1 + 45 * t1 * t1 - 252 * ePrimeSquared - 3 * c1 * c1) * d * d * d * d * d * d / 720
+            );
+
+            double longitude = (
+                d
+                - (1 + 2 * t1 + c1) * d * d * d / 6
+                + (5 - 2 * c1 + 28 * t1 - 3 * c1 * c1 + 8 * ePrimeSquared + 24 * t1 * t1) * d * d * d * d * d / 120
+            ) / Math.Cos(phi1);
+
+            latitude = latitude * 180.0 / Math.PI;
+            longitude = lonOrigin + longitude * 180.0 / Math.PI;
+
+            return (Math.Round(latitude, 8), Math.Round(longitude, 8));
+        }
+
+        /// <summary>
+        /// Versucht einen UTM-String zu parsen (z.B. "32U 461344 5481745" oder "32U461344E5481745N")
+        /// </summary>
+        public static bool TryParseUtm(string input, out int zone, out char band, out double easting, out double northing)
+        {
+            zone = 0;
+            band = ' ';
+            easting = 0;
+            northing = 0;
+
+            if (string.IsNullOrWhiteSpace(input))
+                return false;
+
+            input = input.Trim().ToUpper();
+
+            // Remove common separators
+            input = input.Replace(",", " ").Replace(";", " ").Replace("/", " ");
+            // Remove trailing E/N labels
+            input = input.Replace("E ", " ").Replace("N ", " ");
+
+            // Pattern: "32U 461344 5481745" or "32 U 461344 5481745"
+            var parts = input.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (parts.Length >= 3)
+            {
+                // Try to extract zone and band from first part
+                string zonePart = parts[0];
+                string eastingPart;
+                string northingPart;
+
+                if (zonePart.Length >= 2 && char.IsLetter(zonePart[^1]))
+                {
+                    // "32U" format
+                    if (!int.TryParse(zonePart[..^1], out zone))
+                        return false;
+                    band = zonePart[^1];
+                    eastingPart = parts[1].TrimEnd('E', 'e');
+                    northingPart = parts[2].TrimEnd('N', 'n');
+                }
+                else if (parts.Length >= 4 && int.TryParse(zonePart, out zone) && parts[1].Length == 1 && char.IsLetter(parts[1][0]))
+                {
+                    // "32 U 461344 5481745" format
+                    band = parts[1][0];
+                    eastingPart = parts[2].TrimEnd('E', 'e');
+                    northingPart = parts[3].TrimEnd('N', 'n');
+                }
+                else
+                {
+                    return false;
+                }
+
+                if (zone < 1 || zone > 60)
+                    return false;
+
+                if (!IsValidUtmBand(band))
+                    return false;
+
+                if (!double.TryParse(eastingPart, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out easting))
+                    return false;
+
+                if (!double.TryParse(northingPart, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out northing))
+                    return false;
+
+                // Validate ranges
+                if (easting < 100000 || easting > 900000)
+                    return false;
+
+                if (northing < 0 || northing > 10000000)
+                    return false;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Formatiert einen UTM-Zonenstring (z.B. "32U")
+        /// </summary>
+        public static string FormatUtmZone(int zone, char band) => $"{zone}{band}";
+
+        private static char GetUtmBand(double latitude)
+        {
+            string bands = "CDEFGHJKLMNPQRSTUVWX";
+            if (latitude < -80) return 'C';
+            if (latitude >= 84) return 'X';
+            int index = (int)Math.Floor((latitude + 80) / 8);
+            if (index >= bands.Length) index = bands.Length - 1;
+            return bands[index];
+        }
+
+        private static bool IsValidUtmBand(char band)
+        {
+            return "CDEFGHJKLMNPQRSTUVWX".Contains(char.ToUpper(band));
+        }
+    }
+}

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -175,6 +175,23 @@
             <!-- Karte -->
             <div id="einsatzMap" class="map-wrapper"></div>
 
+            @* Polygon-Bearbeitungsmodus Overlay *@
+            @if (_polygonEditMode)
+            {
+                <div class="polygon-edit-overlay">
+                    <span class="polygon-edit-hint">
+                        <i class="bi bi-vector-pen"></i>
+                        Eckpunkte ziehen zum Verschieben &middot; Mittelpunkte anklicken zum Einfügen &middot; Eckpunkt anklicken + Entf zum Löschen
+                    </span>
+                    <button class="btn btn-success btn-sm" @onclick="SavePolygonEdit">
+                        <i class="bi bi-check-lg"></i> Speichern
+                    </button>
+                    <button class="btn btn-secondary btn-sm" @onclick="CancelPolygonEdit">
+                        <i class="bi bi-x-lg"></i> Abbrechen
+                    </button>
+                </div>
+            }
+
             @* Collar Tracking Panel (schwebt über der Karte) *@
             @if (_trackingVisible)
             {
@@ -354,6 +371,12 @@
                         </div>
 
                         <div class="modal-footer">
+                            @if (_editingArea != null)
+                            {
+                                <button type="button" class="btn btn-outline-primary me-auto" @onclick="StartPolygonEditMode">
+                                    <i class="bi bi-vector-pen"></i> Polygon bearbeiten
+                                </button>
+                            }
                             <button type="button" class="btn btn-secondary" @onclick="CloseDialog">Abbrechen</button>
                             <button type="submit" class="btn btn-success">Speichern</button>
                         </div>
@@ -376,6 +399,10 @@
     private string _lastDrawnGeoJson = "";
     private bool _drawingSaved = false; // Flag: wurde die aktuelle Zeichnung gespeichert?
     private DotNetObjectReference<EinsatzKarte>? _dotNetReference;
+    
+    // Polygon-Bearbeitungsmodus
+    private bool _polygonEditMode = false;
+    private SearchArea? _editingAreaForPolygon = null;
     
     // Standardposition (Speyer, Deutschland)
     private double _mapCenterLat = 49.3188;
@@ -556,6 +583,42 @@
         };
         _selectedTeamId = area.AssignedTeamId;
         _showDialog = true;
+    }
+
+    private async Task StartPolygonEditMode()
+    {
+        if (_editingArea == null) return;
+
+        _editingAreaForPolygon = _editingArea;
+        _showDialog = false;
+        _polygonEditMode = true;
+        StateHasChanged();
+
+        await JSRuntime.InvokeVoidAsync("LeafletMap.startPolygonEdit", "einsatzMap", _editingArea.Id);
+    }
+
+    private async Task SavePolygonEdit()
+    {
+        await JSRuntime.InvokeVoidAsync("LeafletMap.savePolygonEdit", "einsatzMap");
+        _polygonEditMode = false;
+        _editingArea = null;
+        _editingAreaForPolygon = null;
+        StateHasChanged();
+    }
+
+    private async Task CancelPolygonEdit()
+    {
+        await JSRuntime.InvokeVoidAsync("LeafletMap.cancelPolygonEdit", "einsatzMap");
+        _polygonEditMode = false;
+
+        // Dialog erneut öffnen, damit der Nutzer weiterarbeiten kann
+        if (_editingAreaForPolygon != null)
+        {
+            EditSearchArea(_editingAreaForPolygon);
+        }
+
+        _editingAreaForPolygon = null;
+        StateHasChanged();
     }
 
     private async Task SaveArea()
@@ -1054,6 +1117,11 @@
         ExtractCoordinatesFromGeoJson(area);
         await EinsatzService.UpdateSearchAreaAsync(area);
         _searchAreas = EinsatzService.CurrentEinsatz.SearchAreas.ToList();
+
+        // Polygon auf der Karte mit neuem GeoJSON und Originalfarbe/-name neu rendern
+        await JSRuntime.InvokeVoidAsync("LeafletMap.removeSearchArea", "einsatzMap", areaId);
+        await JSRuntime.InvokeVoidAsync("LeafletMap.addSearchArea",
+            "einsatzMap", areaId, geoJson, area.Color, area.Name);
 
         await InvokeAsync(StateHasChanged);
     }

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -1368,8 +1368,7 @@
             TryParseDecimalInput(_editMarkerLng, out var lng) &&
             lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180)
         {
-            var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
-            _editMarkerUtm = $"{Domain.Services.UtmConverter.FormatUtmZone(utmZone, utmBand)} {utmEasting:F0} {utmNorthing:F0}";
+            _editMarkerUtm = FormatUtmString(lat, lng);
         }
     }
 
@@ -1517,8 +1516,7 @@
                 _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
 
                 // UTM automatisch aktualisieren
-                var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
-                _editMarkerUtm = $"{Domain.Services.UtmConverter.FormatUtmZone(utmZone, utmBand)} {utmEasting:F0} {utmNorthing:F0}";
+                _editMarkerUtm = FormatUtmString(lat, lng);
 
                 _editMarkerMessage = "✓ Position aktualisiert. Klicken Sie \"Speichern\" um die Änderung zu übernehmen.";
                 _editMarkerMessageType = "alert-info";
@@ -1537,6 +1535,12 @@
         return double.TryParse(input.Replace(",", "."),
             System.Globalization.NumberStyles.Float,
             System.Globalization.CultureInfo.InvariantCulture, out result);
+    }
+
+    private static string FormatUtmString(double lat, double lng)
+    {
+        var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
+        return $"{Domain.Services.UtmConverter.FormatUtmZone(utmZone, utmBand)} {utmEasting:F0} {utmNorthing:F0}";
     }
 
     [JSInvokable]

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -601,6 +601,7 @@
     {
         await JSRuntime.InvokeVoidAsync("LeafletMap.savePolygonEdit", "einsatzMap");
         _polygonEditMode = false;
+        _showDialog = false;
         _editingArea = null;
         _editingAreaForPolygon = null;
         StateHasChanged();

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -269,6 +269,12 @@
                     <div class="marker-list-section">
                         <div class="marker-list-header">
                             <small class="fw-bold">Gesetzte Punkte (@_mapMarkers.Count)</small>
+                            @if (_mapMarkers.Any())
+                            {
+                                <button class="btn btn-xs btn-link p-0 ms-1" @onclick="DownloadAllMarkersGpx" title="Alle Punkte als GPX herunterladen">
+                                    <i class="bi bi-download"></i>
+                                </button>
+                            }
                         </div>
                         @if (_mapMarkers.Any())
                         {
@@ -295,6 +301,10 @@
                                             <button class="btn btn-xs btn-link p-0" 
                                                     @onclick="() => StartEditMarker(marker)" title="Bearbeiten">
                                                 <i class="bi bi-pencil"></i>
+                                            </button>
+                                            <button class="btn btn-xs btn-link p-0"
+                                                    @onclick="() => DownloadMarkerGpx(marker)" title="GPX herunterladen">
+                                                <i class="bi bi-download"></i>
                                             </button>
                                             <button class="btn btn-xs btn-link text-danger p-0" 
                                                     @onclick="() => RemoveMarker(marker)" title="Entfernen">
@@ -968,6 +978,78 @@
         {
             _searchMessage = $"Fehler beim GPX-Export: {ex.Message}";
             Console.WriteLine($"GPX-Export Fehler: {ex.Message}");
+            StateHasChanged();
+        }
+    }
+
+    private async Task DownloadMarkerGpx(MapMarker marker)
+    {
+        try
+        {
+            var timestamp = marker.CreatedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var displayName = string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label;
+            var safeName = displayName.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+            sb.AppendLine("<gpx version=\"1.1\" creator=\"Einsatzueberwachung.Server\"");
+            sb.AppendLine("     xmlns=\"http://www.topografix.com/GPX/1/1\"");
+            sb.AppendLine("     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
+            sb.AppendLine("     xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\">");
+            sb.AppendLine($"  <wpt lat=\"{marker.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{marker.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
+            sb.AppendLine($"    <name>{safeName}</name>");
+            sb.AppendLine($"    <time>{timestamp}</time>");
+            sb.AppendLine("  </wpt>");
+            sb.AppendLine("</gpx>");
+
+            var safeFileName = (string.IsNullOrEmpty(marker.Label) ? $"Punkt_{marker.FormattedTimestamp}" : marker.Label)
+                .Replace(" ", "_").Replace(":", "-");
+            await JSRuntime.InvokeVoidAsync("downloadFile", $"{safeFileName}.gpx", sb.ToString(), "application/gpx+xml");
+        }
+        catch (Exception ex)
+        {
+            _markerMessage = $"Fehler beim GPX-Export: {ex.Message}";
+            _markerMessageType = "alert-danger";
+            Console.WriteLine($"Marker GPX-Export Fehler: {ex.Message}");
+            StateHasChanged();
+        }
+    }
+
+    private async Task DownloadAllMarkersGpx()
+    {
+        if (!_mapMarkers.Any())
+            return;
+
+        try
+        {
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+            sb.AppendLine("<gpx version=\"1.1\" creator=\"Einsatzueberwachung.Server\"");
+            sb.AppendLine("     xmlns=\"http://www.topografix.com/GPX/1/1\"");
+            sb.AppendLine("     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
+            sb.AppendLine("     xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\">");
+
+            foreach (var marker in _mapMarkers.OrderBy(m => m.CreatedAt))
+            {
+                var timestamp = marker.CreatedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+                var displayName = string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label;
+                var safeName = displayName.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+                sb.AppendLine($"  <wpt lat=\"{marker.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{marker.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
+                sb.AppendLine($"    <name>{safeName}</name>");
+                sb.AppendLine($"    <time>{timestamp}</time>");
+                sb.AppendLine("  </wpt>");
+            }
+
+            sb.AppendLine("</gpx>");
+
+            var dateStamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+            await JSRuntime.InvokeVoidAsync("downloadFile", $"Punkte_{dateStamp}.gpx", sb.ToString(), "application/gpx+xml");
+        }
+        catch (Exception ex)
+        {
+            _markerMessage = $"Fehler beim GPX-Export: {ex.Message}";
+            _markerMessageType = "alert-danger";
+            Console.WriteLine($"Marker GPX-Export Fehler: {ex.Message}");
             StateHasChanged();
         }
     }

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -569,33 +569,35 @@
                             <div class="col-6">
                                 <div class="input-group input-group-sm">
                                     <span class="input-group-text">Lat</span>
-                                    <input type="text" class="form-control" @bind="_editMarkerLat" @bind:event="oninput" />
+                                    <input type="text" class="form-control" value="@_editMarkerLat"
+                                           @oninput="OnEditLatChanged" />
                                 </div>
                             </div>
                             <div class="col-6">
                                 <div class="input-group input-group-sm">
                                     <span class="input-group-text">Lng</span>
-                                    <input type="text" class="form-control" @bind="_editMarkerLng" @bind:event="oninput" />
+                                    <input type="text" class="form-control" value="@_editMarkerLng"
+                                           @oninput="OnEditLngChanged" />
                                 </div>
                             </div>
                         </div>
                     </div>
 
                     <div class="mb-3">
-                        <label class="form-label">oder UTM-Koordinaten</label>
+                        <label class="form-label">UTM-Koordinaten</label>
                         <div class="input-group input-group-sm">
                             <span class="input-group-text">UTM</span>
-                            <input type="text" class="form-control" @bind="_editMarkerUtm" @bind:event="oninput"
+                            <input type="text" class="form-control" value="@_editMarkerUtm"
+                                   @oninput="OnEditUtmChanged"
                                    placeholder="z.B. 32U 461344 5481745" />
-                            <button class="btn btn-outline-secondary" type="button" @onclick="ApplyUtmToEditDialog" title="UTM übernehmen">
-                                <i class="bi bi-arrow-left-right"></i>
-                            </button>
                         </div>
-                        <small class="text-muted">UTM eingeben und mit dem Button in Lat/Long umrechnen.</small>
+                        <small class="text-muted">Änderungen werden automatisch zwischen Lat/Long und UTM synchronisiert.</small>
                     </div>
 
-                    <div class="alert alert-light py-1 px-2">
-                        <small><i class="bi bi-info-circle"></i> Sie können den Marker auch direkt auf der Karte verschieben (Drag &amp; Drop).</small>
+                    <div class="mb-3">
+                        <button type="button" class="btn btn-outline-primary btn-sm w-100" @onclick="StartMarkerDragMode">
+                            <i class="bi bi-arrows-move"></i> Position per Drag auf der Karte ändern
+                        </button>
                     </div>
 
                     @if (!string.IsNullOrEmpty(_editMarkerMessage))
@@ -1341,22 +1343,75 @@
         _editMarkerMessage = "";
     }
 
-    private void ApplyUtmToEditDialog()
+    private void OnEditLatChanged(ChangeEventArgs e)
+    {
+        _editMarkerLat = e.Value?.ToString() ?? "";
+        SyncLatLngToUtm();
+    }
+
+    private void OnEditLngChanged(ChangeEventArgs e)
+    {
+        _editMarkerLng = e.Value?.ToString() ?? "";
+        SyncLatLngToUtm();
+    }
+
+    private void OnEditUtmChanged(ChangeEventArgs e)
+    {
+        _editMarkerUtm = e.Value?.ToString() ?? "";
+        SyncUtmToLatLng();
+    }
+
+    private void SyncLatLngToUtm()
     {
         _editMarkerMessage = "";
-
-        if (!Domain.Services.UtmConverter.TryParseUtm(_editMarkerUtm ?? "", out int zone, out char band, out double easting, out double northing))
+        if (TryParseDecimalInput(_editMarkerLat, out var lat) &&
+            TryParseDecimalInput(_editMarkerLng, out var lng) &&
+            lat >= -90 && lat <= 90 && lng >= -180 && lng <= 180)
         {
-            _editMarkerMessage = "Ungültiges UTM-Format.";
-            _editMarkerMessageType = "alert-danger";
-            return;
+            var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
+            _editMarkerUtm = $"{Domain.Services.UtmConverter.FormatUtmZone(utmZone, utmBand)} {utmEasting:F0} {utmNorthing:F0}";
         }
+    }
 
-        var (lat, lng) = Domain.Services.UtmConverter.UtmToLatLong(zone, band, easting, northing);
-        _editMarkerLat = lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
-        _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
-        _editMarkerMessage = "✓ UTM-Koordinaten in Lat/Long umgerechnet.";
-        _editMarkerMessageType = "alert-success";
+    private void SyncUtmToLatLng()
+    {
+        _editMarkerMessage = "";
+        if (Domain.Services.UtmConverter.TryParseUtm(_editMarkerUtm ?? "", out int zone, out char band, out double easting, out double northing))
+        {
+            var (lat, lng) = Domain.Services.UtmConverter.UtmToLatLong(zone, band, easting, northing);
+            _editMarkerLat = lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+            _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        }
+    }
+
+    private async Task StartMarkerDragMode()
+    {
+        if (_editingMarker == null) return;
+
+        var markerId = _editingMarker.Id;
+        // Dialog schließen (aber Marker-Referenz behalten)
+        _showMarkerEditDialog = false;
+        _editMarkerMessage = "";
+        StateHasChanged();
+
+        // Drag-Modus auf der Karte aktivieren
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("LeafletMap.enableCoordinateMarkerDrag", "einsatzMap", markerId);
+            // Zur Marker-Position zoomen, damit der Nutzer den Marker sieht
+            await JSRuntime.InvokeVoidAsync("LeafletMap.zoomToCoordinateMarker", "einsatzMap", markerId);
+
+            _markerMessage = "Verschieben Sie den Marker auf der Karte. Der Bearbeiten-Dialog öffnet sich nach dem Loslassen.";
+            _markerMessageType = "alert-info";
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            _editMarkerMessage = $"Fehler: {ex.Message}";
+            _editMarkerMessageType = "alert-danger";
+            _showMarkerEditDialog = true;
+            StateHasChanged();
+        }
     }
 
     private async Task SaveMarkerEdit()
@@ -1437,36 +1492,39 @@
     }
 
     [JSInvokable]
-    public async Task OnCoordinateMarkerDragged(string markerId, double lat, double lng)
+    public async Task OnCoordinateMarkerDragCompleted(string markerId, double lat, double lng)
     {
-        await InvokeAsync(async () =>
+        await InvokeAsync(() =>
         {
-            var updated = await EinsatzService.UpdateMapMarkerAsync(markerId, latitude: lat, longitude: lng);
-            if (updated != null)
+            // Finde den Marker, der gerade bearbeitet wird
+            var marker = _editingMarker;
+            if (marker == null || marker.Id != markerId)
             {
-                _mapMarkers = EinsatzService.CurrentEinsatz.MapMarkers.ToList();
+                // Fallback: Marker anhand der ID finden
+                marker = _mapMarkers.FirstOrDefault(m => m.Id == markerId);
+            }
 
-                // Protokolleintrag
-                var noteText = $"📍 Koordinaten-Marker \"{updated.Label}\" verschoben: {updated.FormattedLatLng} (UTM: {updated.FormattedUtm})";
-                await EinsatzService.AddGlobalNoteWithSourceAsync(
-                    noteText,
-                    "system",
-                    "Einsatzleitung",
-                    "Notiz",
-                    Domain.Models.Enums.GlobalNotesEntryType.EinsatzUpdate,
-                    "Karte");
-
-                _markerMessage = $"✓ Marker \"{updated.Label}\" verschoben ({lat:F6}° / {lng:F6}°)";
-                _markerMessageType = "alert-success";
-
-                // Falls Edit-Dialog für diesen Marker offen ist, Felder aktualisieren
-                if (_showMarkerEditDialog && _editingMarker?.Id == markerId)
+            if (marker != null)
+            {
+                // Dialog mit neuen Koordinaten wieder öffnen (ohne zu speichern)
+                _editingMarker = marker;
+                // Label beibehalten (falls nicht gesetzt, vom Marker übernehmen)
+                if (string.IsNullOrEmpty(_editMarkerLabel))
                 {
-                    _editMarkerLat = lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
-                    _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
-                    _editMarkerUtm = updated.FormattedUtm;
+                    _editMarkerLabel = marker.Label;
                 }
+                _editMarkerLat = lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+                _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
 
+                // UTM automatisch aktualisieren
+                var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
+                _editMarkerUtm = $"{Domain.Services.UtmConverter.FormatUtmZone(utmZone, utmBand)} {utmEasting:F0} {utmNorthing:F0}";
+
+                _editMarkerMessage = "✓ Position aktualisiert. Klicken Sie \"Speichern\" um die Änderung zu übernehmen.";
+                _editMarkerMessageType = "alert-info";
+                _showMarkerEditDialog = true;
+
+                _markerMessage = "";
                 StateHasChanged();
             }
         });

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -1115,22 +1115,27 @@
 
     // --- Koordinaten-Marker Methoden ---
 
-    private void ToggleMarkerPanel()
+    private async Task ToggleMarkerPanel()
     {
         _markerPanelVisible = !_markerPanelVisible;
         if (!_markerPanelVisible && _clickToPlaceActive)
         {
-            _ = DeactivateClickToPlaceMode();
+            await DeactivateClickToPlaceMode();
+        }
+        else if (_markerPanelVisible && _coordInputMode == "click" && !_clickToPlaceActive)
+        {
+            // Automatically activate click-to-place when panel opens in click mode
+            await ActivateClickToPlaceMode();
         }
     }
 
-    private void SetCoordInputMode(string mode)
+    private async Task SetCoordInputMode(string mode)
     {
         _coordInputMode = mode;
         _markerMessage = "";
         if (_clickToPlaceActive)
         {
-            _ = DeactivateClickToPlaceMode();
+            await DeactivateClickToPlaceMode();
         }
     }
 

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -190,7 +190,7 @@
                     @* Eingabe-Bereich *@
                     <div class="marker-input-section">
                         <div class="marker-input-tabs">
-                            <button class="btn btn-xs @(_coordInputMode == "click" ? "btn-primary" : "btn-outline-primary")" 
+                            <button class="btn btn-xs @(_clickToPlaceActive ? "btn-primary" : "btn-outline-primary")" 
                                     @onclick="ActivateClickToPlaceMode"
                                     title="Punkt per Mausklick auf Karte setzen">
                                 <i class="bi bi-cursor-fill"></i> Klick
@@ -213,16 +213,6 @@
                                     <input type="text" class="form-control" @bind="_inputMarkerLabel" @bind:event="oninput"
                                            placeholder="Bezeichnung (optional)" />
                                 </div>
-                                @if (_clickToPlaceActive)
-                                {
-                                    <div class="alert alert-info py-1 px-2 mb-0">
-                                        <small><i class="bi bi-cursor-fill"></i> Klicken Sie auf die Karte, um einen Punkt zu setzen.</small>
-                                    </div>
-                                }
-                                else
-                                {
-                                    <small class="text-muted">Klicken Sie "Klick" um den Modus zu aktivieren.</small>
-                                }
                             </div>
                         }
                         else if (_coordInputMode == "latlong")
@@ -264,7 +254,6 @@
                                 <button class="btn btn-sm btn-success w-100" @onclick="PlaceMarkerFromUtm">
                                     <i class="bi bi-pin-map"></i> Punkt setzen
                                 </button>
-                                <small class="text-muted mt-1 d-block">Format: Zone+Band Easting Northing<br/>z.B. 32U 461344 5481745</small>
                             </div>
                         }
 

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -229,6 +229,11 @@
                         @if (_coordInputMode == "click")
                         {
                             <div class="marker-click-hint mt-2">
+                                <div class="input-group input-group-sm mb-1">
+                                    <span class="input-group-text" style="min-width: 35px;"><i class="bi bi-tag"></i></span>
+                                    <input type="text" class="form-control" @bind="_inputMarkerLabel" @bind:event="oninput"
+                                           placeholder="Bezeichnung (optional)" />
+                                </div>
                                 @if (_clickToPlaceActive)
                                 {
                                     <div class="alert alert-info py-1 px-2 mb-0">
@@ -318,10 +323,16 @@
                                                 </span>
                                             }
                                         </div>
-                                        <button class="btn btn-xs btn-link text-danger p-0" 
-                                                @onclick="() => RemoveMarker(marker)" title="Entfernen">
-                                            <i class="bi bi-trash"></i>
-                                        </button>
+                                        <div class="marker-list-actions">
+                                            <button class="btn btn-xs btn-link p-0" 
+                                                    @onclick="() => StartEditMarker(marker)" title="Bearbeiten">
+                                                <i class="bi bi-pencil"></i>
+                                            </button>
+                                            <button class="btn btn-xs btn-link text-danger p-0" 
+                                                    @onclick="() => RemoveMarker(marker)" title="Entfernen">
+                                                <i class="bi bi-trash"></i>
+                                            </button>
+                                        </div>
                                     </div>
                                 }
                             </div>
@@ -535,6 +546,76 @@
     </div>
 }
 
+@if (_showMarkerEditDialog)
+{
+    <div class="modal-backdrop show"></div>
+    <div class="modal show d-block" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><i class="bi bi-pencil"></i> Marker bearbeiten</h5>
+                    <button type="button" class="btn-close" @onclick="CloseMarkerEditDialog"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Bezeichnung</label>
+                        <input type="text" class="form-control" @bind="_editMarkerLabel" @bind:event="oninput"
+                               placeholder="Bezeichnung" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Koordinaten (Lat/Long)</label>
+                        <div class="row g-2">
+                            <div class="col-6">
+                                <div class="input-group input-group-sm">
+                                    <span class="input-group-text">Lat</span>
+                                    <input type="text" class="form-control" @bind="_editMarkerLat" @bind:event="oninput" />
+                                </div>
+                            </div>
+                            <div class="col-6">
+                                <div class="input-group input-group-sm">
+                                    <span class="input-group-text">Lng</span>
+                                    <input type="text" class="form-control" @bind="_editMarkerLng" @bind:event="oninput" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">oder UTM-Koordinaten</label>
+                        <div class="input-group input-group-sm">
+                            <span class="input-group-text">UTM</span>
+                            <input type="text" class="form-control" @bind="_editMarkerUtm" @bind:event="oninput"
+                                   placeholder="z.B. 32U 461344 5481745" />
+                            <button class="btn btn-outline-secondary" type="button" @onclick="ApplyUtmToEditDialog" title="UTM übernehmen">
+                                <i class="bi bi-arrow-left-right"></i>
+                            </button>
+                        </div>
+                        <small class="text-muted">UTM eingeben und mit dem Button in Lat/Long umrechnen.</small>
+                    </div>
+
+                    <div class="alert alert-light py-1 px-2">
+                        <small><i class="bi bi-info-circle"></i> Sie können den Marker auch direkt auf der Karte verschieben (Drag &amp; Drop).</small>
+                    </div>
+
+                    @if (!string.IsNullOrEmpty(_editMarkerMessage))
+                    {
+                        <div class="alert @(_editMarkerMessageType) py-1 px-2 mt-2 mb-0">
+                            <small>@_editMarkerMessage</small>
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="CloseMarkerEditDialog">Abbrechen</button>
+                    <button type="button" class="btn btn-success" @onclick="SaveMarkerEdit">
+                        <i class="bi bi-check-lg"></i> Speichern
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @code {
     private List<SearchArea> _searchAreas = new();
     private List<Team> _teams = new();
@@ -579,6 +660,16 @@
     private string _markerMessage = "";
     private string _markerMessageType = "alert-info";
     private int _markerCounter = 0;
+
+    // Marker-Bearbeitung
+    private bool _showMarkerEditDialog = false;
+    private MapMarker? _editingMarker = null;
+    private string _editMarkerLabel = "";
+    private string _editMarkerLat = "";
+    private string _editMarkerLng = "";
+    private string _editMarkerUtm = "";
+    private string _editMarkerMessage = "";
+    private string _editMarkerMessageType = "alert-info";
 
     protected override void OnInitialized()
     {
@@ -1218,6 +1309,157 @@
     private async Task ZoomToMarker(MapMarker marker)
     {
         await JSRuntime.InvokeVoidAsync("LeafletMap.zoomToCoordinateMarker", "einsatzMap", marker.Id);
+    }
+
+    // --- Marker-Bearbeitung ---
+
+    private void StartEditMarker(MapMarker marker)
+    {
+        _editingMarker = marker;
+        _editMarkerLabel = marker.Label;
+        _editMarkerLat = marker.Latitude.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        _editMarkerLng = marker.Longitude.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        _editMarkerUtm = marker.FormattedUtm;
+        _editMarkerMessage = "";
+        _showMarkerEditDialog = true;
+    }
+
+    private void CloseMarkerEditDialog()
+    {
+        _showMarkerEditDialog = false;
+        _editingMarker = null;
+        _editMarkerMessage = "";
+    }
+
+    private void ApplyUtmToEditDialog()
+    {
+        _editMarkerMessage = "";
+
+        if (!Domain.Services.UtmConverter.TryParseUtm(_editMarkerUtm ?? "", out int zone, out char band, out double easting, out double northing))
+        {
+            _editMarkerMessage = "Ungültiges UTM-Format.";
+            _editMarkerMessageType = "alert-danger";
+            return;
+        }
+
+        var (lat, lng) = Domain.Services.UtmConverter.UtmToLatLong(zone, band, easting, northing);
+        _editMarkerLat = lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+        _editMarkerMessage = "✓ UTM-Koordinaten in Lat/Long umgerechnet.";
+        _editMarkerMessageType = "alert-success";
+    }
+
+    private async Task SaveMarkerEdit()
+    {
+        if (_editingMarker == null) return;
+        _editMarkerMessage = "";
+
+        var newLabel = _editMarkerLabel?.Trim();
+        if (string.IsNullOrWhiteSpace(newLabel))
+        {
+            _editMarkerMessage = "Bitte eine Bezeichnung eingeben.";
+            _editMarkerMessageType = "alert-danger";
+            return;
+        }
+
+        if (!TryParseDecimalInput(_editMarkerLat, out var lat) ||
+            !TryParseDecimalInput(_editMarkerLng, out var lng))
+        {
+            _editMarkerMessage = "Ungültige Koordinaten.";
+            _editMarkerMessageType = "alert-danger";
+            return;
+        }
+
+        if (lat < -90 || lat > 90 || lng < -180 || lng > 180)
+        {
+            _editMarkerMessage = "Koordinaten außerhalb des gültigen Bereichs.";
+            _editMarkerMessageType = "alert-danger";
+            return;
+        }
+
+        var oldLabel = _editingMarker.Label;
+        var positionChanged = Math.Abs(_editingMarker.Latitude - lat) > 0.0000001 || Math.Abs(_editingMarker.Longitude - lng) > 0.0000001;
+        var labelChanged = oldLabel != newLabel;
+
+        // Update im Service
+        var updated = await EinsatzService.UpdateMapMarkerAsync(_editingMarker.Id,
+            label: newLabel,
+            latitude: positionChanged ? lat : null,
+            longitude: positionChanged ? lng : null);
+
+        if (updated == null)
+        {
+            _editMarkerMessage = "Marker nicht gefunden.";
+            _editMarkerMessageType = "alert-danger";
+            return;
+        }
+
+        _mapMarkers = EinsatzService.CurrentEinsatz.MapMarkers.ToList();
+
+        // Marker auf der Karte aktualisieren (entfernen und neu setzen)
+        await JSRuntime.InvokeVoidAsync("LeafletMap.removeCoordinateMarker", "einsatzMap", updated.Id);
+        await JSRuntime.InvokeVoidAsync("LeafletMap.setCoordinateMarker",
+            "einsatzMap", updated.Id, updated.Latitude, updated.Longitude,
+            updated.Label, updated.Description, updated.Color);
+
+        // Protokolleintrag
+        var changes = new List<string>();
+        if (labelChanged) changes.Add($"Bezeichnung: \"{oldLabel}\" → \"{newLabel}\"");
+        if (positionChanged) changes.Add($"Position: {updated.FormattedLatLng} (UTM: {updated.FormattedUtm})");
+
+        if (changes.Count > 0)
+        {
+            var noteText = $"📍 Koordinaten-Marker bearbeitet: {string.Join(", ", changes)}";
+            await EinsatzService.AddGlobalNoteWithSourceAsync(
+                noteText,
+                "system",
+                "Einsatzleitung",
+                "Notiz",
+                Domain.Models.Enums.GlobalNotesEntryType.EinsatzUpdate,
+                "Karte");
+        }
+
+        _markerMessage = $"✓ Marker \"{newLabel}\" aktualisiert.";
+        _markerMessageType = "alert-success";
+
+        CloseMarkerEditDialog();
+        StateHasChanged();
+    }
+
+    [JSInvokable]
+    public async Task OnCoordinateMarkerDragged(string markerId, double lat, double lng)
+    {
+        await InvokeAsync(async () =>
+        {
+            var updated = await EinsatzService.UpdateMapMarkerAsync(markerId, latitude: lat, longitude: lng);
+            if (updated != null)
+            {
+                _mapMarkers = EinsatzService.CurrentEinsatz.MapMarkers.ToList();
+
+                // Protokolleintrag
+                var noteText = $"📍 Koordinaten-Marker \"{updated.Label}\" verschoben: {updated.FormattedLatLng} (UTM: {updated.FormattedUtm})";
+                await EinsatzService.AddGlobalNoteWithSourceAsync(
+                    noteText,
+                    "system",
+                    "Einsatzleitung",
+                    "Notiz",
+                    Domain.Models.Enums.GlobalNotesEntryType.EinsatzUpdate,
+                    "Karte");
+
+                _markerMessage = $"✓ Marker \"{updated.Label}\" verschoben ({lat:F6}° / {lng:F6}°)";
+                _markerMessageType = "alert-success";
+
+                // Falls Edit-Dialog für diesen Marker offen ist, Felder aktualisieren
+                if (_showMarkerEditDialog && _editingMarker?.Id == markerId)
+                {
+                    _editMarkerLat = lat.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+                    _editMarkerLng = lng.ToString("F6", System.Globalization.CultureInfo.InvariantCulture);
+                    _editMarkerUtm = updated.FormattedUtm;
+                }
+
+                StateHasChanged();
+            }
+        });
     }
 
     private static bool TryParseDecimalInput(string? input, out double result)

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -333,12 +333,22 @@
                         @if (_currentArea.Coordinates != null && _currentArea.Coordinates.Count >= 3)
                         {
                             <div class="alert alert-info mb-3">
-                                <strong><i class="bi bi-rulers"></i> Berechnete Fläche:</strong> 
-                                @_currentArea.FormattedArea
-                                <br/>
-                                <small class="text-muted">
-                                    (@_currentArea.Coordinates.Count Punkte)
-                                </small>
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <strong><i class="bi bi-rulers"></i> Berechnete Fläche:</strong>
+                                        @_currentArea.FormattedArea
+                                        <br/>
+                                        <small class="text-muted">
+                                            (@_currentArea.Coordinates.Count Punkte)
+                                        </small>
+                                    </div>
+                                    @if (_editingArea != null)
+                                    {
+                                        <button type="button" class="btn btn-outline-primary btn-sm ms-3" @onclick="StartPolygonEditMode">
+                                            <i class="bi bi-vector-pen"></i> Polygon bearbeiten
+                                        </button>
+                                    }
+                                </div>
                             </div>
                         }
 
@@ -371,12 +381,6 @@
                         </div>
 
                         <div class="modal-footer">
-                            @if (_editingArea != null)
-                            {
-                                <button type="button" class="btn btn-outline-primary me-auto" @onclick="StartPolygonEditMode">
-                                    <i class="bi bi-vector-pen"></i> Polygon bearbeiten
-                                </button>
-                            }
                             <button type="button" class="btn btn-secondary" @onclick="CloseDialog">Abbrechen</button>
                             <button type="submit" class="btn btn-success">Speichern</button>
                         </div>

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -150,6 +150,9 @@
                                     <button class="btn btn-xs btn-link" @onclick="() => EditSearchArea(area)" title="Bearbeiten">
                                         <i class="bi bi-pencil"></i>
                                     </button>
+                                    <button class="btn btn-xs btn-link" @onclick="() => DownloadGpx(area)" title="GPX herunterladen">
+                                        <i class="bi bi-download"></i>
+                                    </button>
                                     <button class="btn btn-xs btn-link text-danger" @onclick="() => DeleteSearchArea(area)" title="Löschen">
                                         <i class="bi bi-trash"></i>
                                     </button>
@@ -608,6 +611,68 @@
         await EinsatzService.DeleteSearchAreaAsync(area.Id);
         await JSRuntime.InvokeVoidAsync("LeafletMap.removeSearchArea", "einsatzMap", area.Id);
         _searchAreas = EinsatzService.CurrentEinsatz.SearchAreas.ToList();
+    }
+
+    private async Task DownloadGpx(SearchArea area)
+    {
+        if (area.Coordinates == null || area.Coordinates.Count < 2)
+        {
+            _searchMessage = "Suchgebiet hat nicht genügend Koordinaten für einen GPX-Track.";
+            StateHasChanged();
+            return;
+        }
+
+        try
+        {
+            var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var safeName = area.Name.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+
+            // Build GPX track as closed polygon (repeat first point at end)
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+            sb.AppendLine("<gpx version=\"1.1\" creator=\"Einsatzueberwachung.Server\"");
+            sb.AppendLine("     xmlns=\"http://www.topografix.com/GPX/1/1\"");
+            sb.AppendLine("     xmlns:gpxx=\"http://www.garmin.com/xmlschemas/GpxExtensions/v3\"");
+            sb.AppendLine("     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
+            sb.AppendLine("     xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\">");
+            sb.AppendLine($"  <trk>");
+            sb.AppendLine($"    <name>{safeName}</name>");
+            sb.AppendLine($"    <desc>Suchgebiet: {safeName}</desc>");
+            sb.AppendLine("    <extensions>");
+            sb.AppendLine("      <gpxx:TrackExtension>");
+            sb.AppendLine("        <gpxx:DisplayColor>Magenta</gpxx:DisplayColor>");
+            sb.AppendLine("      </gpxx:TrackExtension>");
+            sb.AppendLine("    </extensions>");
+            sb.AppendLine("    <trkseg>");
+
+            foreach (var coord in area.Coordinates)
+            {
+                sb.AppendLine($"      <trkpt lat=\"{coord.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{coord.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
+                sb.AppendLine($"        <time>{timestamp}</time>");
+                sb.AppendLine("      </trkpt>");
+            }
+
+            // Close the polygon by repeating the first point
+            var first = area.Coordinates[0];
+            sb.AppendLine($"      <trkpt lat=\"{first.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{first.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
+            sb.AppendLine($"        <time>{timestamp}</time>");
+            sb.AppendLine("      </trkpt>");
+
+            sb.AppendLine("    </trkseg>");
+            sb.AppendLine("  </trk>");
+            sb.AppendLine("</gpx>");
+
+            var gpxContent = sb.ToString();
+            var fileName = $"{area.Name.Replace(" ", "_")}.gpx";
+
+            await JSRuntime.InvokeVoidAsync("downloadFile", fileName, gpxContent, "application/gpx+xml");
+        }
+        catch (Exception ex)
+        {
+            _searchMessage = $"Fehler beim GPX-Export: {ex.Message}";
+            Console.WriteLine($"GPX-Export Fehler: {ex.Message}");
+            StateHasChanged();
+        }
     }
 
     private async Task ZoomToArea(SearchArea area)

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -33,27 +33,6 @@
         </div>
         
         <div class="header-right">
-            <div class="btn-group btn-group-sm" role="group">
-                <button type="button" 
-                        class="btn btn-outline-primary @(_currentMapLayer == "streets" ? "active" : "")" 
-                        @onclick="@(() => ChangeMapLayer("streets"))"
-                        title="Straßenkarte">
-                    <i class="bi bi-map"></i>
-                </button>
-                <button type="button" 
-                        class="btn btn-outline-primary @(_currentMapLayer == "satellite" ? "active" : "")" 
-                        @onclick="@(() => ChangeMapLayer("satellite"))"
-                        title="Satellit">
-                    <i class="bi bi-globe"></i>
-                </button>
-                <button type="button" 
-                        class="btn btn-outline-primary @(_currentMapLayer == "hybrid" ? "active" : "")" 
-                        @onclick="@(() => ChangeMapLayer("hybrid"))"
-                        title="Hybrid">
-                    <i class="bi bi-layers"></i>
-                </button>
-            </div>
-            
             <button class="btn btn-sm btn-outline-info btn-elw" @onclick="SetElwPosition" 
                     title="@(_hasElwPosition ? "ELW verschieben" : "ELW setzen")">
                 <i class="bi bi-geo-fill"></i> @(_hasElwPosition ? "ELW verschieben" : "ELW setzen")
@@ -61,7 +40,7 @@
             <button class="btn btn-sm @(_markerPanelVisible ? "btn-info" : "btn-outline-info")" 
                     @onclick="ToggleMarkerPanel" 
                     title="Koordinaten-Marker">
-                <i class="bi bi-pin-map-fill"></i> Punkte
+                <i class="bi bi-crosshair"></i> Punkte
             </button>
             <button class="btn btn-sm btn-outline-warning" @onclick="PrintMap" title="Drucken">
                 <i class="bi bi-printer"></i>
@@ -202,7 +181,7 @@
             {
                 <div class="coordinate-marker-panel">
                     <div class="marker-panel-header">
-                        <h6><i class="bi bi-pin-map-fill"></i> Koordinaten-Marker</h6>
+                        <h6><i class="bi bi-crosshair"></i> Koordinaten-Marker</h6>
                         <button class="btn btn-sm btn-outline-secondary p-0 px-1" @onclick="ToggleMarkerPanel" title="Schließen">
                             <i class="bi bi-x"></i>
                         </button>
@@ -644,7 +623,6 @@
     
     // ELW-Position
     private bool _hasElwPosition = false;
-    private string _currentMapLayer = "streets";
     private bool _sidebarMinimized = false;
 
     // Collar-Tracking
@@ -1109,20 +1087,6 @@
         {
             _searchMessage = $"Fehler beim Drucken: {ex.Message}";
             Console.WriteLine($"Druck-Fehler: {ex.Message}");
-        }
-    }
-    
-    private async Task ChangeMapLayer(string layerType)
-    {
-        try
-        {
-            _currentMapLayer = layerType;
-            await JSRuntime.InvokeVoidAsync("LeafletMap.changeBaseLayer", "einsatzMap", layerType);
-            StateHasChanged();
-        }
-        catch (Exception ex)
-        {
-            _searchMessage = $"Fehler beim Wechseln der Kartenansicht: {ex.Message}";
         }
     }
 

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -617,6 +617,8 @@
 }
 
 @code {
+    private const double CoordinateEpsilon = 0.0000001;
+    
     private List<SearchArea> _searchAreas = new();
     private List<Team> _teams = new();
     private bool _showDialog = false;
@@ -1240,8 +1242,16 @@
 
     private async Task PlaceMarkerAtPosition(double lat, double lng, string? label = null)
     {
-        _markerCounter++;
-        var markerLabel = !string.IsNullOrWhiteSpace(label) ? label.Trim() : $"P{_markerCounter}";
+        string markerLabel;
+        if (!string.IsNullOrWhiteSpace(label))
+        {
+            markerLabel = label.Trim();
+        }
+        else
+        {
+            _markerCounter++;
+            markerLabel = $"P{_markerCounter}";
+        }
 
         // UTM berechnen
         var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
@@ -1378,7 +1388,7 @@
         }
 
         var oldLabel = _editingMarker.Label;
-        var positionChanged = Math.Abs(_editingMarker.Latitude - lat) > 0.0000001 || Math.Abs(_editingMarker.Longitude - lng) > 0.0000001;
+        var positionChanged = Math.Abs(_editingMarker.Latitude - lat) > CoordinateEpsilon || Math.Abs(_editingMarker.Longitude - lng) > CoordinateEpsilon;
         var labelChanged = oldLabel != newLabel;
 
         // Update im Service

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -982,24 +982,36 @@
         }
     }
 
+    private static string EscapeXml(string text)
+        => text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+
+    private static System.Text.StringBuilder BuildGpxHeader()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        sb.AppendLine("<gpx version=\"1.1\" creator=\"Einsatzueberwachung.Server\"");
+        sb.AppendLine("     xmlns=\"http://www.topografix.com/GPX/1/1\"");
+        sb.AppendLine("     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
+        sb.AppendLine("     xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\">");
+        return sb;
+    }
+
+    private static void AppendWaypoint(System.Text.StringBuilder sb, MapMarker marker)
+    {
+        var timestamp = marker.CreatedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+        var displayName = string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label;
+        sb.AppendLine($"  <wpt lat=\"{marker.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{marker.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
+        sb.AppendLine($"    <name>{EscapeXml(displayName)}</name>");
+        sb.AppendLine($"    <time>{timestamp}</time>");
+        sb.AppendLine("  </wpt>");
+    }
+
     private async Task DownloadMarkerGpx(MapMarker marker)
     {
         try
         {
-            var timestamp = marker.CreatedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
-            var displayName = string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label;
-            var safeName = displayName.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
-
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            sb.AppendLine("<gpx version=\"1.1\" creator=\"Einsatzueberwachung.Server\"");
-            sb.AppendLine("     xmlns=\"http://www.topografix.com/GPX/1/1\"");
-            sb.AppendLine("     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
-            sb.AppendLine("     xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\">");
-            sb.AppendLine($"  <wpt lat=\"{marker.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{marker.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
-            sb.AppendLine($"    <name>{safeName}</name>");
-            sb.AppendLine($"    <time>{timestamp}</time>");
-            sb.AppendLine("  </wpt>");
+            var sb = BuildGpxHeader();
+            AppendWaypoint(sb, marker);
             sb.AppendLine("</gpx>");
 
             var safeFileName = (string.IsNullOrEmpty(marker.Label) ? $"Punkt_{marker.FormattedTimestamp}" : marker.Label)
@@ -1022,24 +1034,9 @@
 
         try
         {
-            var sb = new System.Text.StringBuilder();
-            sb.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-            sb.AppendLine("<gpx version=\"1.1\" creator=\"Einsatzueberwachung.Server\"");
-            sb.AppendLine("     xmlns=\"http://www.topografix.com/GPX/1/1\"");
-            sb.AppendLine("     xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"");
-            sb.AppendLine("     xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\">");
-
+            var sb = BuildGpxHeader();
             foreach (var marker in _mapMarkers.OrderBy(m => m.CreatedAt))
-            {
-                var timestamp = marker.CreatedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
-                var displayName = string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label;
-                var safeName = displayName.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
-                sb.AppendLine($"  <wpt lat=\"{marker.Latitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\" lon=\"{marker.Longitude.ToString("F7", System.Globalization.CultureInfo.InvariantCulture)}\">");
-                sb.AppendLine($"    <name>{safeName}</name>");
-                sb.AppendLine($"    <time>{timestamp}</time>");
-                sb.AppendLine("  </wpt>");
-            }
-
+                AppendWaypoint(sb, marker);
             sb.AppendLine("</gpx>");
 
             var dateStamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -58,6 +58,11 @@
                     title="@(_hasElwPosition ? "ELW verschieben" : "ELW setzen")">
                 <i class="bi bi-geo-fill"></i> @(_hasElwPosition ? "ELW verschieben" : "ELW setzen")
             </button>
+            <button class="btn btn-sm @(_markerPanelVisible ? "btn-info" : "btn-outline-info")" 
+                    @onclick="ToggleMarkerPanel" 
+                    title="Koordinaten-Marker">
+                <i class="bi bi-pin-map-fill"></i> Punkte
+            </button>
             <button class="btn btn-sm btn-outline-warning" @onclick="PrintMap" title="Drucken">
                 <i class="bi bi-printer"></i>
             </button>
@@ -189,6 +194,145 @@
                     <button class="btn btn-secondary btn-sm" @onclick="CancelPolygonEdit">
                         <i class="bi bi-x-lg"></i> Abbrechen
                     </button>
+                </div>
+            }
+
+            @* Koordinaten-Marker Panel (schwebt über der Karte, links) *@
+            @if (_markerPanelVisible)
+            {
+                <div class="coordinate-marker-panel">
+                    <div class="marker-panel-header">
+                        <h6><i class="bi bi-pin-map-fill"></i> Koordinaten-Marker</h6>
+                        <button class="btn btn-sm btn-outline-secondary p-0 px-1" @onclick="ToggleMarkerPanel" title="Schließen">
+                            <i class="bi bi-x"></i>
+                        </button>
+                    </div>
+
+                    @* Eingabe-Bereich *@
+                    <div class="marker-input-section">
+                        <div class="marker-input-tabs">
+                            <button class="btn btn-xs @(_coordInputMode == "click" ? "btn-primary" : "btn-outline-primary")" 
+                                    @onclick="ActivateClickToPlaceMode"
+                                    title="Punkt per Mausklick auf Karte setzen">
+                                <i class="bi bi-cursor-fill"></i> Klick
+                            </button>
+                            <button class="btn btn-xs @(_coordInputMode == "latlong" ? "btn-primary" : "btn-outline-primary")" 
+                                    @onclick='@(() => SetCoordInputMode("latlong"))'>
+                                <i class="bi bi-geo"></i> Lat/Long
+                            </button>
+                            <button class="btn btn-xs @(_coordInputMode == "utm" ? "btn-primary" : "btn-outline-primary")" 
+                                    @onclick='@(() => SetCoordInputMode("utm"))'>
+                                <i class="bi bi-grid-3x3"></i> UTM
+                            </button>
+                        </div>
+
+                        @if (_coordInputMode == "click")
+                        {
+                            <div class="marker-click-hint mt-2">
+                                @if (_clickToPlaceActive)
+                                {
+                                    <div class="alert alert-info py-1 px-2 mb-0">
+                                        <small><i class="bi bi-cursor-fill"></i> Klicken Sie auf die Karte, um einen Punkt zu setzen.</small>
+                                    </div>
+                                }
+                                else
+                                {
+                                    <small class="text-muted">Klicken Sie "Klick" um den Modus zu aktivieren.</small>
+                                }
+                            </div>
+                        }
+                        else if (_coordInputMode == "latlong")
+                        {
+                            <div class="marker-coord-input mt-2">
+                                <div class="input-group input-group-sm mb-1">
+                                    <span class="input-group-text" style="min-width: 35px;">Lat</span>
+                                    <input type="text" class="form-control" @bind="_inputLatitude" @bind:event="oninput"
+                                           placeholder="z.B. 49.31880" />
+                                </div>
+                                <div class="input-group input-group-sm mb-1">
+                                    <span class="input-group-text" style="min-width: 35px;">Lng</span>
+                                    <input type="text" class="form-control" @bind="_inputLongitude" @bind:event="oninput"
+                                           placeholder="z.B. 8.43120" />
+                                </div>
+                                <div class="input-group input-group-sm mb-1">
+                                    <span class="input-group-text" style="min-width: 35px;"><i class="bi bi-tag"></i></span>
+                                    <input type="text" class="form-control" @bind="_inputMarkerLabel" @bind:event="oninput"
+                                           placeholder="Bezeichnung (optional)" />
+                                </div>
+                                <button class="btn btn-sm btn-success w-100" @onclick="PlaceMarkerFromLatLong">
+                                    <i class="bi bi-pin-map"></i> Punkt setzen
+                                </button>
+                            </div>
+                        }
+                        else if (_coordInputMode == "utm")
+                        {
+                            <div class="marker-coord-input mt-2">
+                                <div class="input-group input-group-sm mb-1">
+                                    <span class="input-group-text" style="min-width: 50px;">UTM</span>
+                                    <input type="text" class="form-control" @bind="_inputUtm" @bind:event="oninput"
+                                           placeholder="z.B. 32U 461344 5481745" />
+                                </div>
+                                <div class="input-group input-group-sm mb-1">
+                                    <span class="input-group-text" style="min-width: 50px;"><i class="bi bi-tag"></i></span>
+                                    <input type="text" class="form-control" @bind="_inputMarkerLabel" @bind:event="oninput"
+                                           placeholder="Bezeichnung (optional)" />
+                                </div>
+                                <button class="btn btn-sm btn-success w-100" @onclick="PlaceMarkerFromUtm">
+                                    <i class="bi bi-pin-map"></i> Punkt setzen
+                                </button>
+                                <small class="text-muted mt-1 d-block">Format: Zone+Band Easting Northing<br/>z.B. 32U 461344 5481745</small>
+                            </div>
+                        }
+
+                        @if (!string.IsNullOrEmpty(_markerMessage))
+                        {
+                            <div class="alert @(_markerMessageType) py-1 px-2 mt-2 mb-0">
+                                <small>@_markerMessage</small>
+                            </div>
+                        }
+                    </div>
+
+                    @* Liste der Marker *@
+                    <div class="marker-list-section">
+                        <div class="marker-list-header">
+                            <small class="fw-bold">Gesetzte Punkte (@_mapMarkers.Count)</small>
+                        </div>
+                        @if (_mapMarkers.Any())
+                        {
+                            <div class="marker-list">
+                                @foreach (var marker in _mapMarkers.OrderByDescending(m => m.CreatedAt))
+                                {
+                                    <div class="marker-list-item">
+                                        <div class="marker-list-info" @onclick="() => ZoomToMarker(marker)" title="Zum Punkt zoomen">
+                                            <span class="marker-list-label">
+                                                <i class="bi bi-pin-map-fill" style="color: @marker.Color;"></i>
+                                                @(string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label)
+                                            </span>
+                                            <span class="marker-list-coords text-muted">
+                                                @marker.FormattedLatLng
+                                            </span>
+                                            @if (!string.IsNullOrEmpty(marker.FormattedUtm))
+                                            {
+                                                <span class="marker-list-coords text-muted">
+                                                    @marker.FormattedUtm
+                                                </span>
+                                            }
+                                        </div>
+                                        <button class="btn btn-xs btn-link text-danger p-0" 
+                                                @onclick="() => RemoveMarker(marker)" title="Entfernen">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </div>
+                                }
+                            </div>
+                        }
+                        else
+                        {
+                            <div class="marker-list-empty">
+                                <small class="text-muted">Keine Punkte gesetzt</small>
+                            </div>
+                        }
+                    </div>
                 </div>
             }
 
@@ -423,11 +567,26 @@
     private bool _trackingVisible = false;
     private Dictionary<string, string> _oobWarnings = new();
 
+    // Koordinaten-Marker
+    private List<MapMarker> _mapMarkers = new();
+    private bool _markerPanelVisible = false;
+    private string _coordInputMode = "click"; // "click", "latlong", "utm"
+    private bool _clickToPlaceActive = false;
+    private string _inputLatitude = "";
+    private string _inputLongitude = "";
+    private string _inputUtm = "";
+    private string _inputMarkerLabel = "";
+    private string _markerMessage = "";
+    private string _markerMessageType = "alert-info";
+    private int _markerCounter = 0;
+
     protected override void OnInitialized()
     {
         _searchAreas = EinsatzService.CurrentEinsatz.SearchAreas.ToList();
         _teams = EinsatzService.Teams;
         _collars = CollarTrackingService.Collars.ToList();
+        _mapMarkers = EinsatzService.CurrentEinsatz.MapMarkers.ToList();
+        _markerCounter = _mapMarkers.Count;
         
         // DotNetObjectReference für Callbacks erstellen
         _dotNetReference = DotNetObjectReference.Create(this);
@@ -503,6 +662,14 @@
                         }
                     }
                     StateHasChanged();
+                }
+
+                // Bestehende Koordinaten-Marker auf der Karte wiederherstellen
+                foreach (var marker in _mapMarkers)
+                {
+                    await JSRuntime.InvokeVoidAsync("LeafletMap.setCoordinateMarker",
+                        "einsatzMap", marker.Id, marker.Latitude, marker.Longitude, 
+                        marker.Label, marker.Description, marker.Color);
                 }
             }
             catch (Exception ex)
@@ -885,6 +1052,188 @@
         var colors = new[] { "#FF6B6B", "#4ECDC4", "#45B7D1", "#FFA07A", "#98D8C8", "#F7DC6F", "#BB8FCE", "#85C1E2" };
         var random = new Random();
         return colors[random.Next(colors.Length)];
+    }
+
+    // --- Koordinaten-Marker Methoden ---
+
+    private void ToggleMarkerPanel()
+    {
+        _markerPanelVisible = !_markerPanelVisible;
+        if (!_markerPanelVisible && _clickToPlaceActive)
+        {
+            _ = DeactivateClickToPlaceMode();
+        }
+    }
+
+    private void SetCoordInputMode(string mode)
+    {
+        _coordInputMode = mode;
+        _markerMessage = "";
+        if (_clickToPlaceActive)
+        {
+            _ = DeactivateClickToPlaceMode();
+        }
+    }
+
+    private async Task ActivateClickToPlaceMode()
+    {
+        _coordInputMode = "click";
+        _clickToPlaceActive = true;
+        _markerMessage = "";
+        
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("LeafletMap.enableCoordinateClickMode", "einsatzMap");
+            StateHasChanged();
+        }
+        catch (Exception ex)
+        {
+            _markerMessage = $"Fehler: {ex.Message}";
+            _markerMessageType = "alert-danger";
+            _clickToPlaceActive = false;
+        }
+    }
+
+    private async Task DeactivateClickToPlaceMode()
+    {
+        _clickToPlaceActive = false;
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("LeafletMap.disableCoordinateClickMode", "einsatzMap");
+        }
+        catch { /* ignore */ }
+    }
+
+    private async Task PlaceMarkerFromLatLong()
+    {
+        _markerMessage = "";
+        
+        if (!double.TryParse(_inputLatitude?.Replace(",", "."), 
+            System.Globalization.NumberStyles.Float, 
+            System.Globalization.CultureInfo.InvariantCulture, out var lat) ||
+            !double.TryParse(_inputLongitude?.Replace(",", "."), 
+            System.Globalization.NumberStyles.Float, 
+            System.Globalization.CultureInfo.InvariantCulture, out var lng))
+        {
+            _markerMessage = "Ungültige Koordinaten. Bitte Dezimalgrad eingeben (z.B. 49.31880 / 8.43120).";
+            _markerMessageType = "alert-danger";
+            return;
+        }
+
+        if (lat < -90 || lat > 90 || lng < -180 || lng > 180)
+        {
+            _markerMessage = "Koordinaten außerhalb des gültigen Bereichs.";
+            _markerMessageType = "alert-danger";
+            return;
+        }
+
+        await PlaceMarkerAtPosition(lat, lng, _inputMarkerLabel);
+        _inputLatitude = "";
+        _inputLongitude = "";
+        _inputMarkerLabel = "";
+    }
+
+    private async Task PlaceMarkerFromUtm()
+    {
+        _markerMessage = "";
+
+        if (!Domain.Services.UtmConverter.TryParseUtm(_inputUtm ?? "", out int zone, out char band, out double easting, out double northing))
+        {
+            _markerMessage = "Ungültiges UTM-Format. Bitte z.B. \"32U 461344 5481745\" eingeben.";
+            _markerMessageType = "alert-danger";
+            return;
+        }
+
+        var (lat, lng) = Domain.Services.UtmConverter.UtmToLatLong(zone, band, easting, northing);
+
+        await PlaceMarkerAtPosition(lat, lng, _inputMarkerLabel);
+        _inputUtm = "";
+        _inputMarkerLabel = "";
+    }
+
+    private async Task PlaceMarkerAtPosition(double lat, double lng, string? label = null)
+    {
+        _markerCounter++;
+        var markerLabel = !string.IsNullOrWhiteSpace(label) ? label.Trim() : $"P{_markerCounter}";
+
+        // UTM berechnen
+        var (utmZone, utmBand, utmEasting, utmNorthing) = Domain.Services.UtmConverter.LatLongToUtm(lat, lng);
+
+        var marker = new MapMarker
+        {
+            Label = markerLabel,
+            Latitude = lat,
+            Longitude = lng,
+            UtmZone = Domain.Services.UtmConverter.FormatUtmZone(utmZone, utmBand),
+            UtmEasting = utmEasting,
+            UtmNorthing = utmNorthing,
+            CreatedAt = DateTime.Now
+        };
+
+        // Im Service speichern
+        await EinsatzService.AddMapMarkerAsync(marker);
+        _mapMarkers = EinsatzService.CurrentEinsatz.MapMarkers.ToList();
+
+        // Auf Karte anzeigen
+        await JSRuntime.InvokeVoidAsync("LeafletMap.setCoordinateMarker",
+            "einsatzMap", marker.Id, lat, lng, markerLabel, "", marker.Color);
+
+        // Zur Position zoomen
+        await JSRuntime.InvokeVoidAsync("LeafletMap.centerMap", "einsatzMap", lat, lng, 16);
+
+        // Protokolleintrag: Funkspruch / Notiz automatisch erstellen
+        var noteText = $"📍 Koordinaten-Marker \"{markerLabel}\" gesetzt: {lat:F6}° / {lng:F6}° (UTM: {marker.FormattedUtm})";
+        await EinsatzService.AddGlobalNoteWithSourceAsync(
+            noteText,
+            "system",
+            "Einsatzleitung",
+            "Notiz",
+            Domain.Models.Enums.GlobalNotesEntryType.EinsatzUpdate,
+            "Karte");
+
+        _markerMessage = $"✓ Punkt \"{markerLabel}\" gesetzt ({lat:F6}° / {lng:F6}°)";
+        _markerMessageType = "alert-success";
+
+        StateHasChanged();
+    }
+
+    private async Task RemoveMarker(MapMarker marker)
+    {
+        await EinsatzService.RemoveMapMarkerAsync(marker.Id);
+        _mapMarkers = EinsatzService.CurrentEinsatz.MapMarkers.ToList();
+
+        await JSRuntime.InvokeVoidAsync("LeafletMap.removeCoordinateMarker", "einsatzMap", marker.Id);
+
+        // Protokolleintrag
+        var noteText = $"📍 Koordinaten-Marker \"{marker.Label}\" entfernt ({marker.FormattedLatLng})";
+        await EinsatzService.AddGlobalNoteWithSourceAsync(
+            noteText,
+            "system",
+            "Einsatzleitung",
+            "Notiz",
+            Domain.Models.Enums.GlobalNotesEntryType.EinsatzUpdate,
+            "Karte");
+
+        _markerMessage = $"Punkt \"{marker.Label}\" entfernt.";
+        _markerMessageType = "alert-info";
+        StateHasChanged();
+    }
+
+    private async Task ZoomToMarker(MapMarker marker)
+    {
+        await JSRuntime.InvokeVoidAsync("LeafletMap.zoomToCoordinateMarker", "einsatzMap", marker.Id);
+    }
+
+    [JSInvokable]
+    public async Task OnCoordinateMarkerClicked(double lat, double lng)
+    {
+        _clickToPlaceActive = false;
+        await InvokeAsync(async () =>
+        {
+            await PlaceMarkerAtPosition(lat, lng, _inputMarkerLabel);
+            _inputMarkerLabel = "";
+            StateHasChanged();
+        });
     }
 
     // --- Collar-Tracking Methoden ---

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -1108,12 +1108,8 @@
     {
         _markerMessage = "";
         
-        if (!double.TryParse(_inputLatitude?.Replace(",", "."), 
-            System.Globalization.NumberStyles.Float, 
-            System.Globalization.CultureInfo.InvariantCulture, out var lat) ||
-            !double.TryParse(_inputLongitude?.Replace(",", "."), 
-            System.Globalization.NumberStyles.Float, 
-            System.Globalization.CultureInfo.InvariantCulture, out var lng))
+        if (!TryParseDecimalInput(_inputLatitude, out var lat) ||
+            !TryParseDecimalInput(_inputLongitude, out var lng))
         {
             _markerMessage = "Ungültige Koordinaten. Bitte Dezimalgrad eingeben (z.B. 49.31880 / 8.43120).";
             _markerMessageType = "alert-danger";
@@ -1222,6 +1218,15 @@
     private async Task ZoomToMarker(MapMarker marker)
     {
         await JSRuntime.InvokeVoidAsync("LeafletMap.zoomToCoordinateMarker", "einsatzMap", marker.Id);
+    }
+
+    private static bool TryParseDecimalInput(string? input, out double result)
+    {
+        result = 0;
+        if (string.IsNullOrWhiteSpace(input)) return false;
+        return double.TryParse(input.Replace(",", "."),
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture, out result);
     }
 
     [JSInvokable]

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.css
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.css
@@ -81,3 +81,131 @@
 .map-main {
     position: relative;
 }
+
+/* ========================================
+   Koordinaten-Marker Panel
+   ======================================== */
+.coordinate-marker-panel {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    z-index: 1000;
+    background: var(--bs-body-bg, #fff);
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 8px;
+    padding: 10px;
+    min-width: 280px;
+    max-width: 320px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.marker-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+}
+
+.marker-panel-header h6 {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.marker-input-section {
+    display: flex;
+    flex-direction: column;
+}
+
+.marker-input-tabs {
+    display: flex;
+    gap: 4px;
+}
+
+.marker-input-tabs .btn-xs {
+    font-size: 0.72rem;
+    padding: 2px 8px;
+    flex: 1;
+}
+
+.marker-coord-input .input-group-text {
+    font-size: 0.75rem;
+    padding: 2px 6px;
+}
+
+.marker-coord-input .form-control {
+    font-size: 0.8rem;
+}
+
+.marker-list-section {
+    border-top: 1px solid var(--bs-border-color, #dee2e6);
+    padding-top: 6px;
+}
+
+.marker-list-header {
+    margin-bottom: 4px;
+}
+
+.marker-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.marker-list-item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 4px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    font-size: 0.78rem;
+}
+
+.marker-list-info {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    cursor: pointer;
+    flex: 1;
+    min-width: 0;
+}
+
+.marker-list-info:hover {
+    text-decoration: underline;
+}
+
+.marker-list-label {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.marker-list-coords {
+    font-size: 0.7rem;
+    font-family: monospace;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.marker-list-empty {
+    text-align: center;
+    padding: 8px;
+}
+
+/* Koordinaten-Marker Icon: kein Standard-Leaflet-Styling */
+::deep .coordinate-marker-icon {
+    background: transparent !important;
+    border: none !important;
+}

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.css
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.css
@@ -203,9 +203,3 @@
     text-align: center;
     padding: 8px;
 }
-
-/* Koordinaten-Marker Icon: kein Standard-Leaflet-Styling */
-::deep .coordinate-marker-icon {
-    background: transparent !important;
-    border: none !important;
-}

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.css
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.css
@@ -203,3 +203,10 @@
     text-align: center;
     padding: 8px;
 }
+
+.marker-list-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: center;
+}

--- a/src/Einsatzueberwachung.Server/wwwroot/app.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/app.css
@@ -2496,6 +2496,33 @@ main:has(.map-page-layout) {
     min-width: 50px;
 }
 
+/* Polygon-Bearbeitungsmodus Overlay */
+.polygon-edit-overlay {
+    position: absolute;
+    bottom: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    background: rgba(20, 20, 30, 0.92);
+    color: #fff;
+    padding: 10px 18px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    max-width: 90vw;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.polygon-edit-hint {
+    font-size: 0.85rem;
+    opacity: 0.9;
+    white-space: normal;
+}
+
 /* Responsive */
 @media (max-width: 992px) {
     .map-sidebar {

--- a/src/Einsatzueberwachung.Server/wwwroot/app.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/app.css
@@ -2496,6 +2496,25 @@ main:has(.map-page-layout) {
     min-width: 50px;
 }
 
+/* Live-Flächen-Anzeige: erscheint während des Zeichnens / Bearbeitens im Karten-Container */
+.live-area-display {
+    position: absolute;
+    top: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1001;
+    background: rgba(20, 20, 30, 0.88);
+    color: #fff;
+    padding: 5px 14px;
+    border-radius: 8px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    pointer-events: none;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    white-space: nowrap;
+}
+
 /* Polygon-Bearbeitungsmodus Overlay */
 .polygon-edit-overlay {
     position: absolute;

--- a/src/Einsatzueberwachung.Server/wwwroot/app.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/app.css
@@ -2496,23 +2496,21 @@ main:has(.map-page-layout) {
     min-width: 50px;
 }
 
-/* Live-Flächen-Anzeige: erscheint während des Zeichnens / Bearbeitens im Karten-Container */
-.live-area-display {
-    position: absolute;
-    top: 80px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1001;
+/* Live-Flächen-Anzeige: Leaflet-Tooltip, zentriert im Polygon */
+.leaflet-tooltip.live-area-tooltip {
     background: rgba(20, 20, 30, 0.88);
     color: #fff;
-    padding: 5px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 8px;
+    padding: 5px 14px;
     font-size: 0.9rem;
     font-weight: 600;
-    pointer-events: none;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.15);
     white-space: nowrap;
+    pointer-events: none;
+}
+.leaflet-tooltip.live-area-tooltip::before {
+    display: none;
 }
 
 /* Polygon-Bearbeitungsmodus Overlay */

--- a/src/Einsatzueberwachung.Server/wwwroot/js/layout-tools.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/js/layout-tools.js
@@ -1,3 +1,15 @@
+window.downloadFile = function (fileName, content, mimeType) {
+    var blob = new Blob([content], { type: mimeType });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+};
+
 window.layoutTools = window.layoutTools || {};
 
 window.layoutTools.warningAudio = window.layoutTools.warningAudio || {

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-custom.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-custom.css
@@ -68,3 +68,24 @@
 [data-bs-theme="dark"] .leaflet-popup-tip {
     background: #2d3238;
 }
+
+/* ========================================
+   COORDINATE MARKER STYLES
+   ======================================== */
+
+/* Koordinaten-Marker Icon: kein Leaflet-Hintergrund */
+.coordinate-marker-icon {
+    background: transparent !important;
+    border: none !important;
+}
+
+/* Popup für Koordinaten-Marker */
+.coord-marker-popup {
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+.coord-marker-popup hr {
+    margin: 4px 0;
+    border-color: var(--bs-border-color, #dee2e6);
+}

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -701,6 +701,123 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
         }
     },
     
+    // Aktiviert den Bearbeitungsmodus für ein bestehendes Suchgebiet
+    startPolygonEdit: function(mapId, areaId) {
+        const mapData = this.maps[mapId];
+        if (!mapData) {
+            console.error('Karte nicht gefunden:', mapId);
+            return false;
+        }
+
+        try {
+            const outerLayer = mapData.markers[areaId];
+            if (!outerLayer) {
+                console.error('Layer nicht gefunden für Area:', areaId);
+                return false;
+            }
+
+            // Äußere GeoJSON-Gruppe aus savedAreas entfernen
+            if (mapData.savedAreas.hasLayer(outerLayer)) {
+                mapData.savedAreas.removeLayer(outerLayer);
+            }
+
+            // Inneren Polygon-Layer extrahieren
+            let innerLayer = null;
+            outerLayer.eachLayer(function(l) { innerLayer = l; });
+
+            if (!innerLayer) {
+                console.error('Kein innerer Layer gefunden für Area:', areaId);
+                mapData.savedAreas.addLayer(outerLayer);
+                return false;
+            }
+
+            // Metadaten auf innerem Layer sicherstellen
+            window.LeafletMap.setSearchAreaMetadata(innerLayer, areaId);
+
+            // In drawnItems verschieben (wird von Leaflet.draw bearbeitet)
+            mapData.drawnItems.addLayer(innerLayer);
+
+            // Bearbeitungszustand speichern
+            mapData.editingAreaId = areaId;
+            mapData.editingOuterLayer = outerLayer;
+            mapData.editingInnerLayer = innerLayer;
+
+            // Leaflet.draw Bearbeitungsmodus aktivieren
+            const editHandler = mapData.drawControl._toolbars.edit._modes.edit.handler;
+            editHandler.enable();
+
+            console.log('Polygon-Bearbeitung gestartet für Area:', areaId);
+            return true;
+        } catch (e) {
+            console.error('Fehler beim Starten des Polygon-Edits:', e);
+            return false;
+        }
+    },
+
+    // Speichert die Änderungen der Polygon-Bearbeitung
+    savePolygonEdit: function(mapId) {
+        const mapData = this.maps[mapId];
+        if (!mapData) {
+            console.error('Karte nicht gefunden:', mapId);
+            return false;
+        }
+
+        try {
+            const editHandler = mapData.drawControl._toolbars.edit._modes.edit.handler;
+            // save() feuert L.Draw.Event.EDITED und deaktiviert danach den Edit-Modus
+            editHandler.save();
+
+            // Inneren Layer aus drawnItems entfernen (OnShapeEdited fügt ihn über addSearchArea neu hinzu)
+            if (mapData.editingInnerLayer && mapData.drawnItems.hasLayer(mapData.editingInnerLayer)) {
+                mapData.drawnItems.removeLayer(mapData.editingInnerLayer);
+            }
+
+            // Bearbeitungszustand zurücksetzen
+            mapData.editingAreaId = null;
+            mapData.editingOuterLayer = null;
+            mapData.editingInnerLayer = null;
+
+            return true;
+        } catch (e) {
+            console.error('Fehler beim Speichern des Polygon-Edits:', e);
+            return false;
+        }
+    },
+
+    // Bricht die Polygon-Bearbeitung ab und stellt den Originalzustand wieder her
+    cancelPolygonEdit: function(mapId) {
+        const mapData = this.maps[mapId];
+        if (!mapData) {
+            console.error('Karte nicht gefunden:', mapId);
+            return false;
+        }
+
+        try {
+            const editHandler = mapData.drawControl._toolbars.edit._modes.edit.handler;
+            editHandler.revertLayers();
+            editHandler.disable();
+
+            // Inneren Layer aus drawnItems entfernen und äußeren Layer wiederherstellen
+            if (mapData.editingInnerLayer && mapData.drawnItems.hasLayer(mapData.editingInnerLayer)) {
+                mapData.drawnItems.removeLayer(mapData.editingInnerLayer);
+            }
+
+            if (mapData.editingOuterLayer) {
+                mapData.savedAreas.addLayer(mapData.editingOuterLayer);
+            }
+
+            // Bearbeitungszustand zurücksetzen
+            mapData.editingAreaId = null;
+            mapData.editingOuterLayer = null;
+            mapData.editingInnerLayer = null;
+
+            return true;
+        } catch (e) {
+            console.error('Fehler beim Abbrechen des Polygon-Edits:', e);
+            return false;
+        }
+    },
+
     // Löscht alle Zeichnungen von der Karte
     clearAllDrawings: function(mapId) {
         try {

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -723,12 +723,20 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
 
             // Inneren Polygon-Layer extrahieren
             let innerLayer = null;
-            outerLayer.eachLayer(function(l) { innerLayer = l; });
+            let innerLayerCount = 0;
+            outerLayer.eachLayer(function(l) {
+                innerLayerCount++;
+                if (!innerLayer) innerLayer = l;
+            });
 
             if (!innerLayer) {
                 console.error('Kein innerer Layer gefunden für Area:', areaId);
                 mapData.savedAreas.addLayer(outerLayer);
                 return false;
+            }
+
+            if (innerLayerCount > 1) {
+                console.warn('Mehrere innere Layer gefunden für Area:', areaId, '- nur der erste wird bearbeitet');
             }
 
             // Metadaten auf innerem Layer sicherstellen

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -184,7 +184,63 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             },
             currentLayer: osmLayer
         };
-            
+
+        // ---- Live-Flächen-Anzeige: DOM-Element im Karten-Container ----
+        const liveAreaEl = document.createElement('div');
+        liveAreaEl.className = 'live-area-display';
+        liveAreaEl.style.display = 'none';
+        map.getContainer().appendChild(liveAreaEl);
+        this.maps[mapId].liveAreaEl = liveAreaEl;
+
+        let drawModeActive = false;
+
+        // Hilfsfunktion: Fläche berechnen und anzeigen
+        const showLiveArea = (latLngs) => {
+            if (!latLngs || latLngs.length < 3) return;
+            const area = window.LeafletMap.calcGeodesicArea(latLngs);
+            liveAreaEl.textContent = '\u{1F4D0} ' + window.LeafletMap.formatArea(area);
+            liveAreaEl.style.display = 'block';
+        };
+
+        // Draw-Modus: Vertex gesetzt → Fläche der bestätigten Punkte anzeigen
+        map.on('draw:drawvertex', function() {
+            const polyMode = drawControl._toolbars.draw._modes.polygon;
+            if (!polyMode || !polyMode.handler._poly) return;
+            showLiveArea(polyMode.handler._poly.getLatLngs());
+        });
+
+        // Draw-Modus: Mausbewegung → vorläufige Fläche mit Cursor-Position anzeigen
+        map.on('mousemove', function(e) {
+            if (!drawModeActive) return;
+            const polyMode = drawControl._toolbars.draw._modes.polygon;
+            if (!polyMode || !polyMode.handler._enabled || !polyMode.handler._poly) return;
+            const existing = polyMode.handler._poly.getLatLngs();
+            if (existing.length < 2) return; // mindestens 2 Punkte + Cursor = 3 Ecken nötig
+            showLiveArea(existing.concat([e.latlng]));
+        });
+
+        // Edit-Modus: Vertex gezogen → Fläche live aktualisieren
+        map.on('draw:editvertex', function(e) {
+            if (!e.poly) return;
+            const rings = e.poly.getLatLngs();
+            // getLatLngs() liefert [[LatLng,...]] für Polygone → äußeren Ring nehmen
+            const flat = (rings.length > 0 && rings[0].lat === undefined) ? rings[0] : rings;
+            showLiveArea(flat);
+        });
+
+        // Draw aktiviert / deaktiviert
+        map.on('draw:drawstart', function() { drawModeActive = true; });
+        map.on('draw:drawstop', function() {
+            drawModeActive = false;
+            liveAreaEl.style.display = 'none';
+        });
+
+        // Edit beendet → ausblenden
+        map.on('draw:editstop', function() {
+            liveAreaEl.style.display = 'none';
+        });
+        // ---- Ende Live-Flächen-Anzeige ----
+
         return true;
     } catch (error) {
         error('Fehler beim Initialisieren der Karte:', error);
@@ -824,6 +880,33 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             console.error('Fehler beim Abbrechen des Polygon-Edits:', e);
             return false;
         }
+    },
+
+    // Berechnet geodätische Fläche (m²) aus einem flachen Array von {lat, lng} Objekten.
+    // Verwendet dieselbe sphärische Formel wie die C#-Klasse SearchArea.CalculatePolygonArea.
+    calcGeodesicArea: function(latLngs) {
+        if (!latLngs || latLngs.length < 3) return 0;
+        const R = 6371000.0;
+        let area = 0;
+        const n = latLngs.length;
+        for (let i = 0; i < n; i++) {
+            const p1 = latLngs[i];
+            const p2 = latLngs[(i + 1) % n];
+            const lat1 = p1.lat * Math.PI / 180;
+            const lat2 = p2.lat * Math.PI / 180;
+            const lon1 = p1.lng * Math.PI / 180;
+            const lon2 = p2.lng * Math.PI / 180;
+            area += (lon2 - lon1) * (2 + Math.sin(lat1) + Math.sin(lat2));
+        }
+        return Math.abs(area * R * R / 2.0);
+    },
+
+    // Formatiert Fläche in m²/ha/km² (gleiche Schwellwerte wie C# FormattedArea).
+    formatArea: function(sqm) {
+        if (sqm < 1) return '< 1 m²';
+        if (sqm < 50000) return Math.round(sqm).toLocaleString('de-DE') + ' m²';
+        if (sqm < 1000000) return (sqm / 10000).toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' ha';
+        return (sqm / 1000000).toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + ' km²';
     },
 
     // Löscht alle Zeichnungen von der Karte

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -1009,7 +1009,7 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             const marker = L.marker([lat, lng], {
                 icon: icon,
                 title: label || 'Koordinaten-Marker',
-                draggable: true
+                draggable: false
             }).addTo(mapData.map);
 
             // Popup mit Koordinaten-Info
@@ -1022,25 +1022,6 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
                 <small><strong>UTM:</strong> ${utmInfo}</small>
             </div>`;
             marker.bindPopup(popupHtml);
-
-            // Drag-Handler: aktualisiere Popup und informiere Blazor
-            marker.on('dragend', (e) => {
-                const newPos = e.target.getLatLng();
-                const newUtmInfo = window.LeafletMap._latLngToUtmString(newPos.lat, newPos.lng);
-                const updatedPopup = `<div class="coord-marker-popup">
-                    <strong>${label || 'Punkt'}</strong>
-                    ${description ? '<br><small>' + description + '</small>' : ''}
-                    <hr style="margin: 4px 0;">
-                    <small><strong>Lat/Long:</strong> ${newPos.lat.toFixed(6)}° / ${newPos.lng.toFixed(6)}°</small><br>
-                    <small><strong>UTM:</strong> ${newUtmInfo}</small>
-                </div>`;
-                marker.setPopupContent(updatedPopup);
-
-                if (mapData.dotNetReference) {
-                    mapData.dotNetReference.invokeMethodAsync('OnCoordinateMarkerDragged', markerId, newPos.lat, newPos.lng)
-                        .catch(err => error('Fehler beim Callback OnCoordinateMarkerDragged:', err));
-                }
-            });
 
             mapData.markers[coordMarkerId] = marker;
             return true;
@@ -1122,6 +1103,76 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             return true;
         } catch (err) {
             error('Fehler beim Deaktivieren des Klick-Modus:', err);
+            return false;
+        }
+    },
+
+    // Aktiviert einmaligen Drag-Modus für einen Koordinaten-Marker.
+    // Nach dem Drag wird draggable wieder deaktiviert und der Blazor-Callback aufgerufen.
+    enableCoordinateMarkerDrag: function(mapId, markerId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            const coordMarkerId = 'coord_' + markerId;
+            const marker = mapData.markers[coordMarkerId];
+            if (!marker) return false;
+
+            // Draggable aktivieren
+            marker.dragging.enable();
+            marker.getElement().style.cursor = 'grab';
+
+            // Einmaliger Drag-Handler
+            marker.once('dragend', (e) => {
+                const newPos = e.target.getLatLng();
+
+                // Draggable sofort wieder deaktivieren
+                marker.dragging.disable();
+                marker.getElement().style.cursor = '';
+
+                // Popup aktualisieren
+                const newUtmInfo = window.LeafletMap._latLngToUtmString(newPos.lat, newPos.lng);
+                const title = marker.options.title || 'Punkt';
+                const updatedPopup = `<div class="coord-marker-popup">
+                    <strong>${title}</strong>
+                    <hr style="margin: 4px 0;">
+                    <small><strong>Lat/Long:</strong> ${newPos.lat.toFixed(6)}° / ${newPos.lng.toFixed(6)}°</small><br>
+                    <small><strong>UTM:</strong> ${newUtmInfo}</small>
+                </div>`;
+                marker.setPopupContent(updatedPopup);
+
+                // Callback an Blazor (Koordinaten nur als Vorschlag, nicht gespeichert)
+                if (mapData.dotNetReference) {
+                    mapData.dotNetReference.invokeMethodAsync('OnCoordinateMarkerDragCompleted', markerId, newPos.lat, newPos.lng)
+                        .catch(err => error('Fehler beim Callback OnCoordinateMarkerDragCompleted:', err));
+                }
+            });
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Aktivieren des Marker-Drag-Modus:', err);
+            return false;
+        }
+    },
+
+    // Deaktiviert den Drag-Modus für einen Koordinaten-Marker (falls noch aktiv)
+    disableCoordinateMarkerDrag: function(mapId, markerId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            const coordMarkerId = 'coord_' + markerId;
+            const marker = mapData.markers[coordMarkerId];
+            if (!marker) return false;
+
+            marker.dragging.disable();
+            if (marker.getElement()) {
+                marker.getElement().style.cursor = '';
+            }
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Deaktivieren des Marker-Drag-Modus:', err);
             return false;
         }
     },

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -185,28 +185,41 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             currentLayer: osmLayer
         };
 
-        // ---- Live-Flächen-Anzeige: DOM-Element im Karten-Container ----
-        const liveAreaEl = document.createElement('div');
-        liveAreaEl.className = 'live-area-display';
-        liveAreaEl.style.display = 'none';
-        map.getContainer().appendChild(liveAreaEl);
-        this.maps[mapId].liveAreaEl = liveAreaEl;
+        // ---- Live-Flächen-Anzeige als Leaflet-Tooltip (zentriert im Polygon) ----
+        // Hilfsfunktion: flaches LatLng-Array aus Polygon-getLatLngs() (kann [[...]] sein)
+        const getFlat = (latLngs) => {
+            if (!latLngs || latLngs.length === 0) return [];
+            return (latLngs[0] && latLngs[0].lat === undefined) ? latLngs[0] : latLngs;
+        };
+        // Hilfsfunktion: geometrischer Schwerpunkt (Mittelwert) der Koordinaten
+        const calcCentroid = (latLngs) => {
+            let lat = 0, lng = 0;
+            const n = latLngs.length;
+            for (let i = 0; i < n; i++) { lat += latLngs[i].lat; lng += latLngs[i].lng; }
+            return L.latLng(lat / n, lng / n);
+        };
+
+        const liveAreaTooltip = L.tooltip({ permanent: true, direction: 'center', className: 'live-area-tooltip' });
+
+        const updateLiveArea = (rawLatLngs) => {
+            const flat = getFlat(rawLatLngs);
+            if (!flat || flat.length < 3) return;
+            const area = window.LeafletMap.calcGeodesicArea(flat);
+            liveAreaTooltip.setLatLng(calcCentroid(flat))
+                           .setContent('\u{1F4D0} ' + window.LeafletMap.formatArea(area));
+            if (!map.hasLayer(liveAreaTooltip)) liveAreaTooltip.addTo(map);
+        };
+        const hideLiveArea = () => {
+            if (map.hasLayer(liveAreaTooltip)) liveAreaTooltip.remove();
+        };
 
         let drawModeActive = false;
-
-        // Hilfsfunktion: Fläche berechnen und anzeigen
-        const showLiveArea = (latLngs) => {
-            if (!latLngs || latLngs.length < 3) return;
-            const area = window.LeafletMap.calcGeodesicArea(latLngs);
-            liveAreaEl.textContent = '\u{1F4D0} ' + window.LeafletMap.formatArea(area);
-            liveAreaEl.style.display = 'block';
-        };
 
         // Draw-Modus: Vertex gesetzt → Fläche der bestätigten Punkte anzeigen
         map.on('draw:drawvertex', function() {
             const polyMode = drawControl._toolbars.draw._modes.polygon;
             if (!polyMode || !polyMode.handler._poly) return;
-            showLiveArea(polyMode.handler._poly.getLatLngs());
+            updateLiveArea(polyMode.handler._poly.getLatLngs());
         });
 
         // Draw-Modus: Mausbewegung → vorläufige Fläche mit Cursor-Position anzeigen
@@ -216,30 +229,23 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             if (!polyMode || !polyMode.handler._enabled || !polyMode.handler._poly) return;
             const existing = polyMode.handler._poly.getLatLngs();
             if (existing.length < 2) return; // mindestens 2 Punkte + Cursor = 3 Ecken nötig
-            showLiveArea(existing.concat([e.latlng]));
-        });
-
-        // Edit-Modus: Vertex gezogen → Fläche live aktualisieren
-        map.on('draw:editvertex', function(e) {
-            if (!e.poly) return;
-            const rings = e.poly.getLatLngs();
-            // getLatLngs() liefert [[LatLng,...]] für Polygone → äußeren Ring nehmen
-            const flat = (rings.length > 0 && rings[0].lat === undefined) ? rings[0] : rings;
-            showLiveArea(flat);
+            updateLiveArea(existing.concat([e.latlng]));
         });
 
         // Draw aktiviert / deaktiviert
         map.on('draw:drawstart', function() { drawModeActive = true; });
         map.on('draw:drawstop', function() {
             drawModeActive = false;
-            liveAreaEl.style.display = 'none';
+            hideLiveArea();
         });
 
-        // Edit beendet → ausblenden
-        map.on('draw:editstop', function() {
-            liveAreaEl.style.display = 'none';
-        });
+        // Edit beendet (Speichern oder Abbrechen) → ausblenden
+        map.on('draw:editstop', function() { hideLiveArea(); });
         // ---- Ende Live-Flächen-Anzeige ----
+
+        // Live-Flächen-Hilfsfunktionen für Nutzung in startPolygonEdit speichern
+        this.maps[mapId].updateLiveArea = updateLiveArea;
+        this.maps[mapId].hideLiveArea = hideLiveArea;
 
         return true;
     } catch (error) {
@@ -806,6 +812,17 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             mapData.editingOuterLayer = outerLayer;
             mapData.editingInnerLayer = innerLayer;
 
+            // Live-Flächen-Anzeige: editdrag-Listener für Echtzeit-Updates beim Vertex-Ziehen
+            if (mapData.updateLiveArea) {
+                const onEditDrag = function() {
+                    mapData.updateLiveArea(innerLayer.getLatLngs());
+                };
+                innerLayer.on('editdrag', onEditDrag);
+                mapData._editDragHandler = { layer: innerLayer, fn: onEditDrag };
+                // Fläche sofort beim Start der Bearbeitung anzeigen
+                mapData.updateLiveArea(innerLayer.getLatLngs());
+            }
+
             // Leaflet.draw Bearbeitungsmodus aktivieren
             const editHandler = mapData.drawControl._toolbars.edit._modes.edit.handler;
             editHandler.enable();
@@ -828,7 +845,7 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
 
         try {
             const editHandler = mapData.drawControl._toolbars.edit._modes.edit.handler;
-            // save() feuert L.Draw.Event.EDITED und deaktiviert danach den Edit-Modus
+            // save() feuert L.Draw.Event.EDITED
             editHandler.save();
 
             // Inneren Layer aus drawnItems entfernen (OnShapeEdited fügt ihn über addSearchArea neu hinzu)
@@ -840,6 +857,15 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             mapData.editingAreaId = null;
             mapData.editingOuterLayer = null;
             mapData.editingInnerLayer = null;
+
+            // Editdrag-Listener entfernen
+            if (mapData._editDragHandler) {
+                mapData._editDragHandler.layer.off('editdrag', mapData._editDragHandler.fn);
+                mapData._editDragHandler = null;
+            }
+
+            // Edit-Modus beenden (feuert draw:editstop → blendet Flächen-Anzeige aus)
+            editHandler.disable();
 
             return true;
         } catch (e) {
@@ -857,6 +883,12 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
         }
 
         try {
+            // Editdrag-Listener entfernen (vor revertLayers/disable)
+            if (mapData._editDragHandler) {
+                mapData._editDragHandler.layer.off('editdrag', mapData._editDragHandler.fn);
+                mapData._editDragHandler = null;
+            }
+
             const editHandler = mapData.drawControl._toolbars.edit._modes.edit.handler;
             editHandler.revertLayers();
             editHandler.disable();

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -966,5 +966,217 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             error('Fehler beim Löschen der Zeichnungen:', err);
             return false;
         }
+    },
+
+    // ========================================
+    // Koordinaten-Marker Funktionen
+    // ========================================
+
+    // Setzt einen Koordinaten-Marker auf der Karte (Punkt mit Label)
+    setCoordinateMarker: function(mapId, markerId, lat, lng, label, description, color) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) {
+                error('Karte nicht gefunden:', mapId);
+                return false;
+            }
+
+            // Alten Marker entfernen falls vorhanden
+            const coordMarkerId = 'coord_' + markerId;
+            if (mapData.markers[coordMarkerId]) {
+                mapData.map.removeLayer(mapData.markers[coordMarkerId]);
+                delete mapData.markers[coordMarkerId];
+            }
+
+            const markerColor = color || '#E74C3C';
+
+            // SVG Pin-Icon mit Label-Nummer/Buchstabe
+            const shortLabel = (label || '?').substring(0, 2);
+            const svgIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="30" height="42" viewBox="0 0 30 42">
+                <path fill="${markerColor}" stroke="#333" stroke-width="1.5" d="M15 0 C7 0 0 6.5 0 15 C0 26 15 42 15 42 C15 42 30 26 30 15 C30 6.5 23 0 15 0 Z"/>
+                <circle cx="15" cy="15" r="9" fill="white"/>
+                <text x="15" y="20" font-size="12" font-weight="bold" text-anchor="middle" fill="${markerColor}" font-family="Arial">${shortLabel}</text>
+            </svg>`;
+
+            const icon = L.divIcon({
+                html: svgIcon,
+                iconSize: [30, 42],
+                iconAnchor: [15, 42],
+                popupAnchor: [0, -42],
+                className: 'coordinate-marker-icon'
+            });
+
+            const marker = L.marker([lat, lng], {
+                icon: icon,
+                title: label || 'Koordinaten-Marker'
+            }).addTo(mapData.map);
+
+            // Popup mit Koordinaten-Info
+            const utmInfo = this._latLngToUtmString(lat, lng);
+            const popupHtml = `<div class="coord-marker-popup">
+                <strong>${label || 'Punkt'}</strong>
+                ${description ? '<br><small>' + description + '</small>' : ''}
+                <hr style="margin: 4px 0;">
+                <small><strong>Lat/Long:</strong> ${lat.toFixed(6)}° / ${lng.toFixed(6)}°</small><br>
+                <small><strong>UTM:</strong> ${utmInfo}</small>
+            </div>`;
+            marker.bindPopup(popupHtml);
+
+            mapData.markers[coordMarkerId] = marker;
+            return true;
+        } catch (err) {
+            error('Fehler beim Setzen des Koordinaten-Markers:', err);
+            return false;
+        }
+    },
+
+    // Entfernt einen Koordinaten-Marker
+    removeCoordinateMarker: function(mapId, markerId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            const coordMarkerId = 'coord_' + markerId;
+            if (mapData.markers[coordMarkerId]) {
+                mapData.map.removeLayer(mapData.markers[coordMarkerId]);
+                delete mapData.markers[coordMarkerId];
+                return true;
+            }
+            return false;
+        } catch (err) {
+            error('Fehler beim Entfernen des Koordinaten-Markers:', err);
+            return false;
+        }
+    },
+
+    // Aktiviert den Klick-Modus zum Setzen eines Koordinaten-Markers
+    enableCoordinateClickMode: function(mapId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            // Cursor ändern
+            mapData.map.getContainer().style.cursor = 'crosshair';
+
+            // Einmaliger Klick-Handler
+            const clickHandler = (e) => {
+                const lat = e.latlng.lat;
+                const lng = e.latlng.lng;
+
+                // Cursor zurücksetzen
+                mapData.map.getContainer().style.cursor = '';
+
+                // Callback an Blazor
+                if (mapData.dotNetReference) {
+                    mapData.dotNetReference.invokeMethodAsync('OnCoordinateMarkerClicked', lat, lng);
+                }
+            };
+
+            // Vorherigen Handler entfernen falls vorhanden
+            if (mapData._coordClickHandler) {
+                mapData.map.off('click', mapData._coordClickHandler);
+            }
+            mapData._coordClickHandler = clickHandler;
+            mapData.map.once('click', clickHandler);
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Aktivieren des Klick-Modus:', err);
+            return false;
+        }
+    },
+
+    // Deaktiviert den Klick-Modus
+    disableCoordinateClickMode: function(mapId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            mapData.map.getContainer().style.cursor = '';
+            if (mapData._coordClickHandler) {
+                mapData.map.off('click', mapData._coordClickHandler);
+                mapData._coordClickHandler = null;
+            }
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Deaktivieren des Klick-Modus:', err);
+            return false;
+        }
+    },
+
+    // Zentriert die Karte auf einen Koordinaten-Marker
+    zoomToCoordinateMarker: function(mapId, markerId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            const coordMarkerId = 'coord_' + markerId;
+            const marker = mapData.markers[coordMarkerId];
+            if (marker) {
+                const pos = marker.getLatLng();
+                mapData.map.setView([pos.lat, pos.lng], 16);
+                marker.openPopup();
+                return true;
+            }
+            return false;
+        } catch (err) {
+            error('Fehler beim Zoomen zum Marker:', err);
+            return false;
+        }
+    },
+
+    // Hilfs-Funktion: Lat/Long zu UTM-String (vereinfachte JS-Implementierung)
+    _latLngToUtmString: function(lat, lng) {
+        try {
+            const zone = Math.floor((lng + 180) / 6) + 1;
+            const bands = 'CDEFGHJKLMNPQRSTUVWX';
+            let bandIndex = Math.floor((lat + 80) / 8);
+            if (bandIndex < 0) bandIndex = 0;
+            if (bandIndex >= bands.length) bandIndex = bands.length - 1;
+            const band = bands[bandIndex];
+
+            // Vereinfachte UTM-Berechnung
+            const a = 6378137.0;
+            const e2 = 0.00669437999014;
+            const k0 = 0.9996;
+            const lonOrigin = (zone - 1) * 6 - 180 + 3;
+
+            const latRad = lat * Math.PI / 180;
+            const lonRad = lng * Math.PI / 180;
+            const lonOriginRad = lonOrigin * Math.PI / 180;
+
+            const ePrime2 = e2 / (1 - e2);
+            const n = a / Math.sqrt(1 - e2 * Math.sin(latRad) * Math.sin(latRad));
+            const t = Math.tan(latRad) * Math.tan(latRad);
+            const c = ePrime2 * Math.cos(latRad) * Math.cos(latRad);
+            const aa = Math.cos(latRad) * (lonRad - lonOriginRad);
+
+            const m = a * (
+                (1 - e2 / 4 - 3 * e2 * e2 / 64 - 5 * e2 * e2 * e2 / 256) * latRad
+                - (3 * e2 / 8 + 3 * e2 * e2 / 32 + 45 * e2 * e2 * e2 / 1024) * Math.sin(2 * latRad)
+                + (15 * e2 * e2 / 256 + 45 * e2 * e2 * e2 / 1024) * Math.sin(4 * latRad)
+                - (35 * e2 * e2 * e2 / 3072) * Math.sin(6 * latRad)
+            );
+
+            let easting = k0 * n * (
+                aa + (1 - t + c) * aa * aa * aa / 6
+                + (5 - 18 * t + t * t + 72 * c - 58 * ePrime2) * aa * aa * aa * aa * aa / 120
+            ) + 500000;
+
+            let northing = k0 * (
+                m + n * Math.tan(latRad) * (
+                    aa * aa / 2
+                    + (5 - t + 9 * c + 4 * c * c) * aa * aa * aa * aa / 24
+                    + (61 - 58 * t + t * t + 600 * c - 330 * ePrime2) * aa * aa * aa * aa * aa * aa / 720
+                )
+            );
+
+            if (lat < 0) northing += 10000000;
+
+            return `${zone}${band} ${Math.round(easting)} E / ${Math.round(northing)} N`;
+        } catch (err) {
+            return 'N/A';
+        }
     }
 };

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -1008,7 +1008,8 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
 
             const marker = L.marker([lat, lng], {
                 icon: icon,
-                title: label || 'Koordinaten-Marker'
+                title: label || 'Koordinaten-Marker',
+                draggable: true
             }).addTo(mapData.map);
 
             // Popup mit Koordinaten-Info
@@ -1021,6 +1022,25 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
                 <small><strong>UTM:</strong> ${utmInfo}</small>
             </div>`;
             marker.bindPopup(popupHtml);
+
+            // Drag-Handler: aktualisiere Popup und informiere Blazor
+            marker.on('dragend', (e) => {
+                const newPos = e.target.getLatLng();
+                const newUtmInfo = window.LeafletMap._latLngToUtmString(newPos.lat, newPos.lng);
+                const updatedPopup = `<div class="coord-marker-popup">
+                    <strong>${label || 'Punkt'}</strong>
+                    ${description ? '<br><small>' + description + '</small>' : ''}
+                    <hr style="margin: 4px 0;">
+                    <small><strong>Lat/Long:</strong> ${newPos.lat.toFixed(6)}° / ${newPos.lng.toFixed(6)}°</small><br>
+                    <small><strong>UTM:</strong> ${newUtmInfo}</small>
+                </div>`;
+                marker.setPopupContent(updatedPopup);
+
+                if (mapData.dotNetReference) {
+                    mapData.dotNetReference.invokeMethodAsync('OnCoordinateMarkerDragged', markerId, newPos.lat, newPos.lng)
+                        .catch(err => error('Fehler beim Callback OnCoordinateMarkerDragged:', err));
+                }
+            });
 
             mapData.markers[coordMarkerId] = marker;
             return true;

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -1068,7 +1068,8 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
 
                 // Callback an Blazor
                 if (mapData.dotNetReference) {
-                    mapData.dotNetReference.invokeMethodAsync('OnCoordinateMarkerClicked', lat, lng);
+                    mapData.dotNetReference.invokeMethodAsync('OnCoordinateMarkerClicked', lat, lng)
+                        .catch(err => error('Fehler beim Callback OnCoordinateMarkerClicked:', err));
                 }
             };
 

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -991,7 +991,7 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             const markerColor = color || '#E74C3C';
 
             // SVG Pin-Icon mit Label-Nummer/Buchstabe
-            const shortLabel = (label || '?').substring(0, 2);
+            const shortLabel = ((label && label.trim()) || '?').substring(0, 2);
             const svgIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="30" height="42" viewBox="0 0 30 42">
                 <path fill="${markerColor}" stroke="#333" stroke-width="1.5" d="M15 0 C7 0 0 6.5 0 15 C0 26 15 42 15 42 C15 42 30 26 30 15 C30 6.5 23 0 15 0 Z"/>
                 <circle cx="15" cy="15" r="9" fill="white"/>

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -988,7 +988,7 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
                 delete mapData.markers[coordMarkerId];
             }
 
-            const markerColor = color || '#E74C3C';
+            const markerColor = color || '#2196F3';
 
             // SVG Pin-Icon mit Label-Nummer/Buchstabe
             const shortLabel = ((label && label.trim()) || '?').substring(0, 2);
@@ -1059,6 +1059,24 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             // Cursor ändern
             mapData.map.getContainer().style.cursor = 'crosshair';
 
+            // Suchgebiete temporär nicht-interaktiv machen, damit der Klick durchkommt
+            if (mapData.savedAreas) {
+                mapData.savedAreas.eachLayer(function(layer) {
+                    if (layer.eachLayer) {
+                        layer.eachLayer(function(subLayer) {
+                            if (subLayer.getElement) {
+                                const el = subLayer.getElement();
+                                if (el) el.style.pointerEvents = 'none';
+                            }
+                        });
+                    }
+                    if (layer.getElement) {
+                        const el = layer.getElement();
+                        if (el) el.style.pointerEvents = 'none';
+                    }
+                });
+            }
+
             // Einmaliger Klick-Handler
             const clickHandler = (e) => {
                 const lat = e.latlng.lat;
@@ -1066,6 +1084,24 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
 
                 // Cursor zurücksetzen
                 mapData.map.getContainer().style.cursor = '';
+
+                // Suchgebiete wieder interaktiv machen
+                if (mapData.savedAreas) {
+                    mapData.savedAreas.eachLayer(function(layer) {
+                        if (layer.eachLayer) {
+                            layer.eachLayer(function(subLayer) {
+                                if (subLayer.getElement) {
+                                    const el = subLayer.getElement();
+                                    if (el) el.style.pointerEvents = '';
+                                }
+                            });
+                        }
+                        if (layer.getElement) {
+                            const el = layer.getElement();
+                            if (el) el.style.pointerEvents = '';
+                        }
+                    });
+                }
 
                 // Callback an Blazor
                 if (mapData.dotNetReference) {
@@ -1098,6 +1134,24 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             if (mapData._coordClickHandler) {
                 mapData.map.off('click', mapData._coordClickHandler);
                 mapData._coordClickHandler = null;
+            }
+
+            // Suchgebiete wieder interaktiv machen
+            if (mapData.savedAreas) {
+                mapData.savedAreas.eachLayer(function(layer) {
+                    if (layer.eachLayer) {
+                        layer.eachLayer(function(subLayer) {
+                            if (subLayer.getElement) {
+                                const el = subLayer.getElement();
+                                if (el) el.style.pointerEvents = '';
+                            }
+                        });
+                    }
+                    if (layer.getElement) {
+                        const el = layer.getElement();
+                        if (el) el.style.pointerEvents = '';
+                    }
+                });
             }
 
             return true;

--- a/src/Einsatzueberwachung.Server/wwwroot/print-map.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/print-map.css
@@ -27,6 +27,9 @@
     .input-group,
     .badge:not(.print-legend *):not(.print-list-page *),
     .top-row,
+    .mission-topbar,
+    .map-header,
+    .map-sidebar,
     .header-with-clock,
     .live-datetime,
     #live-datetime,
@@ -61,6 +64,7 @@
         width: 100% !important;
         max-width: 100% !important;
         left: 0 !important;
+        overflow: visible !important;
     }
     
     /* Grid/Flex Layout überschreiben */
@@ -68,6 +72,26 @@
     .page main {
         margin-left: 0 !important;
         width: 100% !important;
+    }
+
+    /* Karten-Layout: map-content Flex zurücksetzen, damit map-main die volle Breite nutzt */
+    .map-content {
+        display: block !important;
+        width: 100% !important;
+        overflow: visible !important;
+    }
+
+    .map-main {
+        width: 100% !important;
+        overflow: visible !important;
+    }
+
+    .map-page-layout {
+        overflow: visible !important;
+    }
+
+    .app-content:has(.map-page-layout) {
+        overflow: visible !important;
     }
     
     /* Verstecke die normale Suchgebiete-Tabelle (nicht druckoptimiert) */


### PR DESCRIPTION
Für die Übertragung von Suchgebieten steht der export als GPX-Datei jetzt zur verfügung (kompatibel mit vielen Apps und GPS-Geräten):
<img width="301" height="143" alt="image" src="https://github.com/user-attachments/assets/d9276300-ac54-4658-8a26-52a0e73ac7b2" />

Suchgebiete können jetzt auch bearbeitet werden:
<img width="808" height="437" alt="image" src="https://github.com/user-attachments/assets/52a75a4c-82c7-43f3-b8d6-09b2baffe6f2" />
<img width="802" height="678" alt="image" src="https://github.com/user-attachments/assets/89b3ef7f-6285-4124-90cd-82eaf33a292a" />

Interessante punkte können gesetzt werden, entweder durch mausklick auf der Karte oder durch das eingeben von Koordinaten (Wichtig, falls von den Suchteams Positionen durchgegeben werden).
<img width="1438" height="686" alt="image" src="https://github.com/user-attachments/assets/29eddc4c-fbe4-4eec-9b4b-e0889938a9b1" />
<img width="302" height="549" alt="image" src="https://github.com/user-attachments/assets/9f070b38-dc7b-4a29-849d-b5f1370f7182" />
<img width="295" height="594" alt="image" src="https://github.com/user-attachments/assets/17992320-7c2b-418a-8087-84282b2a5b48" />


