### PR TITLE
Fix Hilfe-Drawer auto-scroll locking manual reading (#31)

### DIFF
--- a/src/Einsatzueberwachung.Server/Components/Shared/HilfeDrawer.razor
+++ b/src/Einsatzueberwachung.Server/Components/Shared/HilfeDrawer.razor
@@ -43,24 +43,44 @@
 @code {
     [Parameter] public bool IsOpen { get; set; }
     [Parameter] public EventCallback OnClose { get; set; }
+    private bool _wasOpen;
+    private string? _lastAnchorId;
 
     protected override async Task OnParametersSetAsync()
     {
-        if (IsOpen)
+        if (!IsOpen)
         {
-            await ScrollToCurrentPageAsync();
+            _wasOpen = false;
+            _lastAnchorId = null;
+            return;
         }
+
+        var anchorId = GetCurrentAnchorId();
+        var drawerJustOpened = !_wasOpen;
+        var pageChanged = !string.Equals(_lastAnchorId, anchorId, StringComparison.Ordinal);
+
+        if (drawerJustOpened || pageChanged)
+        {
+            await ScrollToSectionAsync(anchorId);
+            _lastAnchorId = anchorId;
+        }
+
+        _wasOpen = true;
     }
 
-    private async Task ScrollToCurrentPageAsync()
+    private string GetCurrentAnchorId()
     {
         var path = new Uri(Nav.Uri).AbsolutePath.TrimEnd('/');
         if (string.IsNullOrEmpty(path))
             path = "/";
 
-        var anchorId = path == "/"
+        return path == "/"
             ? "hilfe-home"
             : "hilfe-" + path.TrimStart('/').Replace("/", "-");
+    }
+
+    private async Task ScrollToSectionAsync(string anchorId)
+    {
 
         try
         {

--- a/src/Einsatzueberwachung.Server/wwwroot/js/hilfe-drawer.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/js/hilfe-drawer.js
@@ -3,7 +3,10 @@ window.hilfeDrawer = {
         const body = document.getElementById('hilfeDrawerBody');
         const el = document.getElementById(id);
         if (body && el) {
-            body.scrollTo({ top: el.offsetTop - 8, behavior: 'smooth' });
+            const bodyRect = body.getBoundingClientRect();
+            const elementRect = el.getBoundingClientRect();
+            const targetTop = Math.max(0, body.scrollTop + (elementRect.top - bodyRect.top) - 8);
+            body.scrollTo({ top: targetTop, behavior: 'smooth' });
         }
     }
 };


### PR DESCRIPTION
Hilfe scrollt jetzt zum richtigen punkt

<img width="644" height="471" alt="image" src="https://github.com/user-attachments/assets/a7003b39-fa14-4fd6-967a-4024b4112961" />


und man kann jetzt scrollen
<img width="669" height="551" alt="image" src="https://github.com/user-attachments/assets/03455bcd-5cf9-441a-98f0-18cea1417e95" />
