### PR TITLE
51 karte aufräumen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.suo
 *.user
 *.userosscache
+*.lscache
 *.sln.docstates
 
 # User-specific files (MonoDevelop/Xamarin Studio)

--- a/src/Einsatzueberwachung.Domain/Interfaces/IPdfExportService.cs
+++ b/src/Einsatzueberwachung.Domain/Interfaces/IPdfExportService.cs
@@ -44,6 +44,16 @@ namespace Einsatzueberwachung.Domain.Interfaces
             List<Team> teams,
             MapTileType tileType = MapTileType.Streets,
             string? filterTeamId = null);
+
+        /// <summary>
+        /// Exportiert eine Einsatzkarte als PDF mit erweiterten Optionen für Layer-Sichtbarkeit.
+        /// </summary>
+        Task<byte[]> ExportEinsatzKarteToPdfBytesAsync(
+            EinsatzData einsatzData,
+            List<Team> teams,
+            MapPrintOptions options,
+            List<TeamTrackSnapshot>? gpsTracks = null,
+            Dictionary<string, List<TeamPhoneLocation>>? phoneTrackHistories = null);
     }
 
     public class PdfExportResult

--- a/src/Einsatzueberwachung.Domain/Interfaces/IStaticMapRenderer.cs
+++ b/src/Einsatzueberwachung.Domain/Interfaces/IStaticMapRenderer.cs
@@ -39,4 +39,18 @@ public interface IStaticMapRenderer
         MapTileType tileType = MapTileType.Streets,
         int width = 1500,
         int height = 1060);
+
+    /// <summary>
+    /// Rendert eine Planungskarte mit erweiterten Layer-Optionen (Marker, GPS-Tracks, Handy-Tracks).
+    /// </summary>
+    Task<byte[]?> RenderSearchAreaMapAsync(
+        List<SearchArea> searchAreas,
+        (double Latitude, double Longitude)? elwPosition,
+        MapPrintOptions options,
+        List<MapMarker>? markers = null,
+        List<TeamTrackSnapshot>? gpsTracks = null,
+        Dictionary<string, List<TeamPhoneLocation>>? phoneTrackHistories = null,
+        List<Team>? teams = null,
+        int width = 1500,
+        int height = 1060);
 }

--- a/src/Einsatzueberwachung.Domain/Models/Enums/MapTileType.cs
+++ b/src/Einsatzueberwachung.Domain/Models/Enums/MapTileType.cs
@@ -4,5 +4,7 @@ public enum MapTileType
 {
     Streets,
     Satellite,
-    Topographic
+    Topographic,
+    SatelliteGoogle,
+    Hybrid
 }

--- a/src/Einsatzueberwachung.Domain/Models/MapPrintOptions.cs
+++ b/src/Einsatzueberwachung.Domain/Models/MapPrintOptions.cs
@@ -1,0 +1,22 @@
+using Einsatzueberwachung.Domain.Models.Enums;
+
+namespace Einsatzueberwachung.Domain.Models;
+
+/// <summary>
+/// Options for the Einsatzkarte PDF print, controlling which layers are visible.
+/// </summary>
+public class MapPrintOptions
+{
+    public MapTileType TileType { get; set; } = MapTileType.Streets;
+    public string? FilterTeamId { get; set; }
+    public bool ShowSearchAreas { get; set; } = true;
+    public bool ShowPointMarkers { get; set; } = true;
+    public bool ShowGpsTracks { get; set; } = false;
+    public bool ShowPhoneTracks { get; set; } = false;
+    /// <summary>Koordinatengitter: "none", "latlon" oder "utm"</summary>
+    public string GridType { get; set; } = "none";
+    public string ZoomMode { get; set; } = "all"; // "all", "team", "viewport"
+    public double? CenterLat { get; set; }
+    public double? CenterLng { get; set; }
+    public int? ZoomLevel { get; set; }
+}

--- a/src/Einsatzueberwachung.Domain/Services/PdfExportService.Map.cs
+++ b/src/Einsatzueberwachung.Domain/Services/PdfExportService.Map.cs
@@ -193,6 +193,86 @@ namespace Einsatzueberwachung.Domain.Services
             });
         }
 
+        public async Task<byte[]> ExportEinsatzKarteToPdfBytesAsync(
+            EinsatzData einsatzData,
+            List<Team> teams,
+            MapPrintOptions options,
+            List<TeamTrackSnapshot>? gpsTracks = null,
+            Dictionary<string, List<TeamPhoneLocation>>? phoneTrackHistories = null)
+        {
+            var staffelInfo = await ResolveStaffelInfoAsync(einsatzData);
+
+            var allAreas = einsatzData.SearchAreas ?? new List<SearchArea>();
+            var filteredAreas = string.IsNullOrWhiteSpace(options.FilterTeamId)
+                ? allAreas
+                : allAreas.Where(a => a.AssignedTeamId == options.FilterTeamId ||
+                    (!string.IsNullOrWhiteSpace(a.AssignedTeamName) &&
+                     teams.Any(t => t.TeamId == options.FilterTeamId &&
+                                    string.Equals(t.TeamName, a.AssignedTeamName, StringComparison.OrdinalIgnoreCase))))
+                          .ToList();
+
+            var filteredTeams = string.IsNullOrWhiteSpace(options.FilterTeamId)
+                ? teams
+                : teams.Where(t => t.TeamId == options.FilterTeamId).ToList();
+
+            var markers = options.ShowPointMarkers ? (einsatzData.MapMarkers ?? new List<MapMarker>()) : null;
+
+            byte[]? mapBytes = null;
+            if (_mapRenderer != null)
+            {
+                mapBytes = await _mapRenderer.RenderSearchAreaMapAsync(
+                    filteredAreas, einsatzData.ElwPosition, options,
+                    markers, gpsTracks, phoneTrackHistories, teams);
+            }
+
+            var capturedMapBytes = mapBytes;
+            return await Task.Run(() =>
+            {
+                using var stream = new MemoryStream();
+                Document.Create(container =>
+                {
+                    container.Page(page =>
+                    {
+                        page.Size(PageSizes.A4.Landscape());
+                        page.MarginTop(4, Unit.Millimetre);
+                        page.MarginBottom(6, Unit.Millimetre);
+                        page.MarginHorizontal(10, Unit.Millimetre);
+                        page.PageColor(Colors.White);
+
+                        page.Header().PaddingBottom(3)
+                            .Element(c => ComposeKarteHeader(c, einsatzData, staffelInfo));
+
+                        page.Content().Element(c =>
+                        {
+                            if (capturedMapBytes != null)
+                            {
+                                c.Image(capturedMapBytes).FitArea();
+                            }
+                            else
+                            {
+                                c.Background(Colors.Grey.Lighten3)
+                                 .AlignCenter().AlignMiddle()
+                                 .Text("Keine Suchgebiete oder ELW-Position vorhanden")
+                                 .FontSize(14).FontColor(Colors.Grey.Darken2);
+                            }
+                        });
+                    });
+
+                    container.Page(page =>
+                    {
+                        page.Size(PageSizes.A4.Landscape());
+                        page.Margin(12, Unit.Millimetre);
+                        page.PageColor(Colors.White);
+                        page.DefaultTextStyle(x => x.FontSize(10));
+
+                        page.Content().Element(c => ComposeKarteListe(c, einsatzData, filteredAreas, filteredTeams));
+                    });
+                }).GeneratePdf(stream);
+
+                return stream.ToArray();
+            });
+        }
+
         private static void ComposeKarteHeader(IContainer container, EinsatzData einsatzData, StaffelInfo staffelInfo)
         {
             container.Background("#2C3E50").Padding(6).Row(row =>

--- a/src/Einsatzueberwachung.Server/Components/Layout/MainLayout.razor
+++ b/src/Einsatzueberwachung.Server/Components/Layout/MainLayout.razor
@@ -70,6 +70,10 @@
                 }
             </div>
 
+            <div class="mission-topbar-page-slot @(MissionTopbar.Content is null ? "is-empty" : "")">
+                @MissionTopbar.Content
+            </div>
+
             <div class="mission-topbar-clock" aria-live="polite">
                 @if (EinsatzService.CurrentEinsatz.AlarmierungsZeit.HasValue)
                     {

--- a/src/Einsatzueberwachung.Server/Components/Layout/MainLayout.razor
+++ b/src/Einsatzueberwachung.Server/Components/Layout/MainLayout.razor
@@ -1,4 +1,4 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 @using Einsatzueberwachung.Domain.Models
 @using Einsatzueberwachung.Domain.Models.Enums
 
@@ -76,13 +76,16 @@
 
             <div class="mission-topbar-clock" aria-live="polite">
                 @if (EinsatzService.CurrentEinsatz.AlarmierungsZeit.HasValue)
-                    {
-                        <span id="live-duration">
-                            <i class="bi bi-clock-history"></i>@GetMissionDurationDisplay()
-                        </span>
-                    }
-                <span id="live-time">00:00:00</span>
-                <span id="live-date">01.01.2000</span>
+                {
+                    <span id="live-duration" class="mission-topbar-duration">
+                        <i class="bi bi-clock-history text-warning"></i>
+                        <span>@GetMissionDurationDisplay()</span>
+                    </span>
+                }
+                <div class="mission-topbar-time-block">
+                    <span id="live-time" class="time-display">00:00:00</span>
+                    <span id="live-date" class="date-display">01.01.2000</span>
+                </div>
             </div>
 
             <div class="mission-topbar-actions">

--- a/src/Einsatzueberwachung.Server/Components/Layout/MainLayout.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Layout/MainLayout.razor.cs
@@ -16,6 +16,7 @@ public partial class MainLayout : LayoutComponentBase, IAsyncDisposable
     [Inject] private TrainerNotificationService TrainerNotifications { get; set; } = default!;
     [Inject] private IWarningService WarningService { get; set; } = default!;
     [Inject] private ITimeService TimeService { get; set; } = default!;
+    [Inject] private MissionTopbarService MissionTopbar { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
 
@@ -34,7 +35,6 @@ public partial class MainLayout : LayoutComponentBase, IAsyncDisposable
     private bool _szenarioMenuOpen;
     private TimeSpan? _missionDuration;
     private System.Threading.Timer? _missionDurationTimer;
-
     private WarningEntry? _lastWarning;
 
     private bool HasActiveEinsatz =>
@@ -58,6 +58,12 @@ public partial class MainLayout : LayoutComponentBase, IAsyncDisposable
         EinsatzService.DogPauseStarted += OnDogPauseStarted;
         TrainerNotifications.ExerciseEnded += OnExerciseEnded;
         WarningService.WarningAdded += OnWarningAdded;
+        MissionTopbar.Changed += OnMissionTopbarChanged;
+    }
+
+    private void OnMissionTopbarChanged()
+    {
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void OnWarningAdded(WarningEntry warning)
@@ -358,6 +364,7 @@ public partial class MainLayout : LayoutComponentBase, IAsyncDisposable
         EinsatzService.DogPauseStarted -= OnDogPauseStarted;
         TrainerNotifications.ExerciseEnded -= OnExerciseEnded;
         WarningService.WarningAdded -= OnWarningAdded;
+        MissionTopbar.Changed -= OnMissionTopbarChanged;
         _missionDurationTimer?.Dispose();
 
         try

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -1,4 +1,4 @@
-﻿@page "/einsatz/karte"
+@page "/einsatz/karte"
 @page "/einsatz-karte"
 @using Einsatzueberwachung.Domain.Interfaces
 @using Einsatzueberwachung.Server.Components.Pages.KarteComponents
@@ -9,52 +9,6 @@
 <PageTitle>Karte | Einsatzüberwachung</PageTitle>
 
 <div class="map-page-layout">
-    <!-- Header -->
-    <header class="map-header">
-        <div class="header-left">
-            <h1><i class="bi bi-map-fill"></i> Karte</h1>
-        </div>
-        
-        <div class="header-center">
-            <div class="input-group input-group-sm">
-                <input type="text" 
-                       class="form-control" 
-                       @bind="_addressSearch" 
-                       @bind:event="oninput"
-                       placeholder="Adresse suchen..." 
-                       aria-label="Adresse suchen" />
-                <button class="btn btn-primary" @onclick="SearchAddress" aria-label="Adresse suchen">
-                    <i class="bi bi-search"></i>
-                </button>
-            </div>
-        </div>
-        
-        <div class="header-right">
-            <button class="btn btn-sm theme-accent-btn btn-elw" @onclick="SetElwPosition" 
-                    title="@(_hasElwPosition ? "ELW verschieben" : "ELW setzen")">
-                <i class="bi bi-geo-fill"></i> @(_hasElwPosition ? "ELW verschieben" : "ELW setzen")
-            </button>
-            <button class="btn btn-sm btn-secondary"
-                    @onclick="ToggleMarkerPanel"
-                    title="Koordinaten-Marker">
-                <i class="bi bi-crosshair"></i> Punkte
-            </button>
-            <button class="btn btn-sm btn-secondary" @onclick="() => _showKarteDialog = true" title="Einsatzkarte drucken">
-                <i class="bi bi-printer" aria-hidden="true"></i>
-            </button>
-            <button class="btn btn-sm @(_trackingVisible ? "btn-success" : "btn-outline-secondary")"
-                    @onclick="ToggleTrackingLayer"
-                    title="@(_trackingVisible ? "GPS-Layer ausblenden" : "GPS-Layer einblenden")">
-                <i class="bi bi-broadcast"></i> GPS
-            </button>
-            <button class="btn btn-sm @(_phoneLayerVisible ? "btn-success" : "btn-outline-secondary")"
-                    @onclick="TogglePhoneLayer"
-                    title="@(_phoneLayerVisible ? "Handy-GPS ausblenden" : "Handy-GPS einblenden")">
-                <i class="bi bi-phone"></i> Handy
-            </button>
-        </div>
-    </header>
-
     @if (!string.IsNullOrWhiteSpace(_searchMessage))
     {
         <div class="search-message">
@@ -169,8 +123,10 @@
                     {
                         <KartePunkteTab @ref="_punkteTab"
                                         Markers="_mapMarkers"
+                                        HasElwPosition="_hasElwPosition"
                                         ClickToPlaceActive="_clickToPlaceActive"
                                         CoordInputMode="_coordInputMode"
+                                        OnSetElwPosition="SetElwPosition"
                                         CoordInputModeChanged="OnCoordInputModeChanged"
                                         OnActivateClickToPlace="ActivateClickToPlaceMode"
                                         OnDeactivateClickToPlace="DeactivateClickToPlaceMode"
@@ -185,17 +141,126 @@
             <!-- Karte -->
             <div id="einsatzMap" class="map-wrapper"></div>
 
+            <div class="map-floating-controls">
+                <div class="map-control-panel">
+                    <button class="map-control-trigger" type="button" @onclick="ToggleMapContentMenu">
+                        <span class="map-control-trigger-label">
+                            <i class="bi bi-layers"></i>
+                            <span>Anzeige</span>
+                        </span>
+                        <span class="map-control-trigger-value">@MapContentSummary</span>
+                        <i class="bi @(_mapContentMenuExpanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
+                    </button>
+
+                    @if (_mapContentMenuExpanded)
+                    {
+                        <div class="map-control-body">
+                            <label class="map-control-check">
+                                <input type="checkbox" checked="@_searchAreasVisible" @onchange="() => ToggleSearchAreasVisibility()" />
+                                <span><i class="bi bi-geo-alt"></i> Suchgebiete</span>
+                            </label>
+                            <label class="map-control-check">
+                                <input type="checkbox" checked="@_pointMarkersVisible" @onchange="() => TogglePointMarkersVisibility()" />
+                                <span><i class="bi bi-crosshair"></i> Punkte</span>
+                            </label>
+                            <label class="map-control-check">
+                                <input type="checkbox" checked="@_trackingVisible" @onchange="() => ToggleTrackingLayer()" />
+                                <span><i class="bi bi-broadcast"></i> GPS</span>
+                            </label>
+                            <label class="map-control-check">
+                                <input type="checkbox" checked="@_phoneLayerVisible" @onchange="() => TogglePhoneLayer()" />
+                                <span><i class="bi bi-phone"></i> Handy</span>
+                            </label>
+                        </div>
+                    }
+                </div>
+
+                <div class="map-control-panel">
+                    <button class="map-control-trigger" type="button" @onclick="ToggleTileMenu">
+                        <span class="map-control-trigger-label">
+                            <i class="bi bi-map"></i>
+                            <span>Kartentyp</span>
+                        </span>
+                        <span class="map-control-trigger-value">@SelectedMapLayerLabel</span>
+                        <i class="bi @(_mapTileMenuExpanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
+                    </button>
+
+                    @if (_mapTileMenuExpanded)
+                    {
+                        <div class="map-control-body">
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "streets")" @onchange='() => ChangeMapBaseLayerAsync("streets")' />
+                                <span>Straßenkarte</span>
+                            </label>
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "satellite")" @onchange='() => ChangeMapBaseLayerAsync("satellite")' />
+                                <span>Satellit (Esri)</span>
+                            </label>
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "satelliteGoogle")" @onchange='() => ChangeMapBaseLayerAsync("satelliteGoogle")' />
+                                <span>Satellit (Google)</span>
+                            </label>
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "hybrid")" @onchange='() => ChangeMapBaseLayerAsync("hybrid")' />
+                                <span>Hybrid (Google)</span>
+                            </label>
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "topo")" @onchange='() => ChangeMapBaseLayerAsync("topo")' />
+                                <span>Topografisch</span>
+                            </label>
+                        </div>
+                    }
+                </div>
+
+                <div class="map-control-panel">
+                    <button class="map-control-trigger" type="button" @onclick="ToggleGridMenu">
+                        <span class="map-control-trigger-label">
+                            <i class="bi bi-grid-3x3"></i>
+                            <span>Koordinaten-Gitter</span>
+                        </span>
+                        <span class="map-control-trigger-value">@SelectedGridLayerLabel</span>
+                        <i class="bi @(_mapGridMenuExpanded ? "bi-chevron-up" : "bi-chevron-down")"></i>
+                    </button>
+
+                    @if (_mapGridMenuExpanded)
+                    {
+                        <div class="map-control-body">
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "none")" @onchange='() => ChangeGridLayerAsync("none")' />
+                                <span>Ohne</span>
+                            </label>
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "utm")" @onchange='() => ChangeGridLayerAsync("utm")' />
+                                <span>UTM</span>
+                            </label>
+                            <label class="map-control-radio">
+                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "latlon")" @onchange='() => ChangeGridLayerAsync("latlon")' />
+                                <span>Lat/Lon (dezimal)</span>
+                            </label>
+                        </div>
+                    }
+                </div>
+            </div>
+
+            <button class="map-floating-action map-floating-action-print"
+                    type="button"
+                    @onclick="() => _showKarteDialog = true"
+                    title="Einsatzkarte drucken">
+                <i class="bi bi-printer" aria-hidden="true"></i>
+                <span>Drucken</span>
+            </button>
+
             @* ── Embed-Toolbar (nur sichtbar bei ?embed=true mit passenden controls=...) ── *@
             <div class="map-embed-toolbar map-embed-tiles" aria-label="Kartentyp">
-                <button class="map-embed-btn @(_karteTileType == "streets" ? "map-embed-btn-on" : "")"
+                <button class="map-embed-btn @(_mapBaseLayerType == "streets" ? "map-embed-btn-on" : "")"
                         @onclick='() => SetEmbedTileType("streets")' title="Straßenkarte">
                     <i class="bi bi-map"></i>
                 </button>
-                <button class="map-embed-btn @(_karteTileType == "satellite" ? "map-embed-btn-on" : "")"
+                <button class="map-embed-btn @(_mapBaseLayerType == "satellite" ? "map-embed-btn-on" : "")"
                         @onclick='() => SetEmbedTileType("satellite")' title="Satellit">
                     <i class="bi bi-globe-europe-africa"></i>
                 </button>
-                <button class="map-embed-btn @(_karteTileType == "topo" ? "map-embed-btn-on" : "")"
+                <button class="map-embed-btn @(_mapBaseLayerType == "topo" ? "map-embed-btn-on" : "")"
                         @onclick='() => SetEmbedTileType("topo")' title="Topografisch">
                     <i class="bi bi-triangle"></i>
                 </button>

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -89,7 +89,8 @@
                                          OnZoomToArea="ZoomToArea"
                                          OnEdit="EditSearchArea"
                                          OnDownloadGpx="DownloadGpx"
-                                         OnDelete="DeleteSearchArea" />
+                                         OnDelete="DeleteSearchArea"
+                                         OnNavigateToTeam="NavigateToTeamInMonitor" />
                     }
 
                     @if (_activeSidebarTab == "gps")
@@ -106,7 +107,8 @@
                                   OnZoomToCollar="ZoomToCollarAsync"
                                   OnZoomToTrack="ZoomToCompletedTrackAsync"
                                   OnToggleTrackVisibility="HandleToggleTrackVisibility"
-                                  OnGpxImported="HandleGpxImportedAsync" />
+                                  OnGpxImported="HandleGpxImportedAsync"
+                                  OnNavigateToTeam="NavigateToTeamInMonitor" />
                     }
 
                     @if (_activeSidebarTab == "handy")
@@ -116,7 +118,8 @@
                                        PhoneTrackHistories="EinsatzService.GetAllPhoneTrackHistories()"
                                        PhoneLayerVisible="_phoneLayerVisible"
                                        OnZoomToTeam="ZoomToPhoneTeamAsync"
-                                       OnTogglePhoneLayer="TogglePhoneLayer" />
+                                       OnTogglePhoneLayer="TogglePhoneLayer"
+                                       OnNavigateToTeam="NavigateToTeamInMonitor" />
                     }
 
                     @if (_activeSidebarTab == "points")

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor
@@ -191,24 +191,24 @@
                     @if (_mapTileMenuExpanded)
                     {
                         <div class="map-control-body">
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "streets")" @onchange='() => ChangeMapBaseLayerAsync("streets")' />
+                            <label class="map-control-radio" @onclick='() => ChangeMapBaseLayerAsync("streets")' >
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "streets")" />
                                 <span>Straßenkarte</span>
                             </label>
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "satellite")" @onchange='() => ChangeMapBaseLayerAsync("satellite")' />
+                            <label class="map-control-radio" @onclick='() => ChangeMapBaseLayerAsync("satellite")' >
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "satellite")" />
                                 <span>Satellit (Esri)</span>
                             </label>
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "satelliteGoogle")" @onchange='() => ChangeMapBaseLayerAsync("satelliteGoogle")' />
+                            <label class="map-control-radio" @onclick='() => ChangeMapBaseLayerAsync("satelliteGoogle")' >
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "satelliteGoogle")" />
                                 <span>Satellit (Google)</span>
                             </label>
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "hybrid")" @onchange='() => ChangeMapBaseLayerAsync("hybrid")' />
+                            <label class="map-control-radio" @onclick='() => ChangeMapBaseLayerAsync("hybrid")' >
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "hybrid")" />
                                 <span>Hybrid (Google)</span>
                             </label>
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "topo")" @onchange='() => ChangeMapBaseLayerAsync("topo")' />
+                            <label class="map-control-radio" @onclick='() => ChangeMapBaseLayerAsync("topo")' >
+                                <input type="radio" name="mapBaseLayer" checked="@(_mapBaseLayerType == "topo")" />
                                 <span>Topografisch</span>
                             </label>
                         </div>
@@ -228,16 +228,16 @@
                     @if (_mapGridMenuExpanded)
                     {
                         <div class="map-control-body">
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "none")" @onchange='() => ChangeGridLayerAsync("none")' />
+                            <label class="map-control-radio" @onclick='() => ChangeGridLayerAsync("none")' >
+                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "none")" />
                                 <span>Ohne</span>
                             </label>
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "utm")" @onchange='() => ChangeGridLayerAsync("utm")' />
+                            <label class="map-control-radio" @onclick='() => ChangeGridLayerAsync("utm")' >
+                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "utm")" />
                                 <span>UTM</span>
                             </label>
-                            <label class="map-control-radio">
-                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "latlon")" @onchange='() => ChangeGridLayerAsync("latlon")' />
+                            <label class="map-control-radio" @onclick='() => ChangeGridLayerAsync("latlon")' >
+                                <input type="radio" name="mapGridLayer" checked="@(_gridLayerType == "latlon")" />
                                 <span>Lat/Lon (dezimal)</span>
                             </label>
                         </div>
@@ -247,7 +247,7 @@
 
             <button class="map-floating-action map-floating-action-print"
                     type="button"
-                    @onclick="() => _showKarteDialog = true"
+                    @onclick="OpenPrintDialogAsync"
                     title="Einsatzkarte drucken">
                 <i class="bi bi-printer" aria-hidden="true"></i>
                 <span>Drucken</span>
@@ -337,49 +337,222 @@
 {
     <div class="modal-backdrop show"></div>
     <div class="modal show d-block" tabindex="-1">
-        <div class="modal-dialog modal-sm">
+        <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title"><i class="bi bi-printer me-2"></i>Einsatzkarte drucken</h5>
                     <button type="button" class="btn-close" @onclick="() => _showKarteDialog = false"></button>
                 </div>
-                <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label fw-bold">Kartentyp</label>
-                        <div class="d-grid gap-1">
-                            <label class="border rounded px-3 py-2 @(_karteTileType == "streets" ? "border-warning bg-warning bg-opacity-10" : "") cursor-pointer">
-                                <input type="radio" name="karteMapType" class="me-2" value="streets"
-                                       checked="@(_karteTileType == "streets")"
-                                       @onchange='() => _karteTileType = "streets"' />
-                                <i class="bi bi-map me-1"></i>Straßenkarte
-                            </label>
-                            <label class="border rounded px-3 py-2 @(_karteTileType == "satellite" ? "border-warning bg-warning bg-opacity-10" : "") cursor-pointer">
-                                <input type="radio" name="karteMapType" class="me-2" value="satellite"
-                                       checked="@(_karteTileType == "satellite")"
-                                       @onchange='() => _karteTileType = "satellite"' />
-                                <i class="bi bi-globe me-1"></i>Satellit
-                            </label>
-                            <label class="border rounded px-3 py-2 @(_karteTileType == "topo" ? "border-warning bg-warning bg-opacity-10" : "") cursor-pointer">
-                                <input type="radio" name="karteMapType" class="me-2" value="topo"
-                                       checked="@(_karteTileType == "topo")"
-                                       @onchange='() => _karteTileType = "topo"' />
-                                <i class="bi bi-bar-chart-steps me-1"></i>Topografisch
-                            </label>
-                        </div>
-                    </div>
-                    <div class="mb-2">
-                        <label class="form-label fw-bold">Team</label>
-                        <select class="form-select form-select-sm" @bind="_karteTeamFilter">
-                            <option value="">Alle Teams</option>
-                            @foreach (var team in _teams.Where(t => !string.IsNullOrWhiteSpace(t.TeamName)).OrderBy(t => t.TeamName))
-                            {
-                                <option value="@team.TeamId">@team.TeamName</option>
-                            }
-                        </select>
-                        @if (!string.IsNullOrWhiteSpace(_karteTeamFilter))
-                        {
-                            <small class="text-muted">Nur Suchgebiete dieses Teams werden gedruckt.</small>
+                <div class="modal-body p-3 print-dialog-inputs">
+                    <style>
+                        .print-dialog-inputs .form-check-input {
+                            min-width: 16px !important;
+                            min-height: 16px !important;
+                            width: 16px !important;
+                            height: 16px !important;
+                            margin: 0 !important;
+                            padding: 0 !important;
+                            cursor: pointer;
+                            flex-shrink: 0;
                         }
+                        
+                        .print-dialog-inputs .form-check {
+                            min-height: auto;
+                            padding: 0;
+                            margin: 0;
+                        }
+
+                        .print-dialog-inputs .align-items-start .form-check-input {
+                            margin-top: 3px !important;
+                        }
+
+                        .print-dialog-inputs .extra-small {
+                            font-size: 0.72rem;
+                            line-height: 1.1;
+                        }
+                    </style>
+                    <div class="mb-3 d-flex justify-content-between align-items-center bg-dark bg-opacity-25 p-2 rounded border border-secondary border-opacity-30">
+                        <span class="text-muted small"><i class="bi bi-info-circle me-1"></i>Passen Sie den Ausschnitt und die Details für den Export an.</span>
+                        <button class="btn btn-outline-warning btn-sm" @onclick="SyncPrintDialogFromMap">
+                            <i class="bi bi-arrow-repeat me-1"></i>Kartenansicht übernehmen
+                        </button>
+                    </div>
+                    
+                    <div class="row g-3">
+                        <!-- Linke Spalte: Ausschnitt, Team & Sichtbarkeit -->
+                        <div class="col-md-6 d-flex flex-column gap-3">
+                            <div>
+                                <label class="form-label fw-bold mb-2"><i class="bi bi-zoom-in me-1 text-warning"></i>1. Kartenausschnitt / Zoom</label>
+                                <div class="d-flex flex-column gap-2 ms-1">
+                                    <div class="form-check d-flex align-items-start">
+                                        <input class="form-check-input" type="radio" name="karteZoomMode" id="zoomModeAll" value="all"
+                                               checked="@(_karteZoomMode == "all")"
+                                               @onchange='() => _karteZoomMode = "all"' />
+                                        <label class="form-check-label ms-2 cursor-pointer" for="zoomModeAll">
+                                            <strong class="d-block text-white small">Alles anzeigen</strong>
+                                            <span class="text-muted extra-small">Gebiete, Tracks & Punkte im Bild</span>
+                                        </label>
+                                    </div>
+                                    
+                                    <div class="form-check d-flex align-items-start @(string.IsNullOrWhiteSpace(_karteTeamFilter) ? "opacity-50" : "")">
+                                        <input class="form-check-input" type="radio" name="karteZoomMode" id="zoomModeTeam" value="team"
+                                               disabled="@(string.IsNullOrWhiteSpace(_karteTeamFilter))"
+                                               checked="@(_karteZoomMode == "team")"
+                                               @onchange='() => _karteZoomMode = "team"' />
+                                        <label class="form-check-label ms-2 cursor-pointer" for="zoomModeTeam">
+                                            <strong class="d-block text-white small">Team-Inhalt fokussieren</strong>
+                                            <span class="text-muted extra-small">Nur Gebiete/Tracks des gewählten Teams</span>
+                                        </label>
+                                    </div>
+
+                                    <div class="form-check d-flex align-items-start">
+                                        <input class="form-check-input" type="radio" name="karteZoomMode" id="zoomModeViewport" value="viewport"
+                                               checked="@(_karteZoomMode == "viewport")"
+                                               @onchange='() => _karteZoomMode = "viewport"' />
+                                        <label class="form-check-label ms-2 cursor-pointer" for="zoomModeViewport">
+                                            <strong class="d-block text-white small">Aktueller Live-Ausschnitt</strong>
+                                            <span class="text-muted extra-small">Identisch mit der Live-Kartenansicht</span>
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label class="form-label fw-bold mb-1 small">Gewähltes Team</label>
+                                <select class="form-select form-select-sm bg-dark text-white border-secondary border-opacity-50" value="@_karteTeamFilter" @onchange="HandleTeamFilterChanged">
+                                    <option value="">Alle Teams</option>
+                                    @foreach (var team in _teams.Where(t => !string.IsNullOrWhiteSpace(t.TeamName)).OrderBy(t => t.TeamName))
+                                    {
+                                        <option value="@team.TeamId">@team.TeamName</option>
+                                    }
+                                </select>
+                                @if (string.IsNullOrWhiteSpace(_karteTeamFilter) && _karteZoomMode == "team")
+                                {
+                                    <span class="text-danger mt-1 d-block" style="font-size: 0.72rem;"><i class="bi bi-exclamation-triangle me-1"></i>Bitte wählen Sie ein Team aus.</span>
+                                }
+                            </div>
+
+                            <div>
+                                <label class="form-label fw-bold mb-2"><i class="bi bi-eye me-1 text-warning"></i>2. Anzeige-Details</label>
+                                <div class="row g-2 ms-1">
+                                    <div class="col-6">
+                                        <div class="form-check d-flex align-items-center">
+                                            <input class="form-check-input" type="checkbox" id="chkSearchAreas" checked="@_karteShowSearchAreas"
+                                                   @onchange="() => _karteShowSearchAreas = !_karteShowSearchAreas" />
+                                            <label class="form-check-label ms-2 cursor-pointer small text-white" for="chkSearchAreas">
+                                                Suchgebiete
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="form-check d-flex align-items-center">
+                                            <input class="form-check-input" type="checkbox" id="chkPoints" checked="@_karteShowPoints"
+                                                   @onchange="() => _karteShowPoints = !_karteShowPoints" />
+                                            <label class="form-check-label ms-2 cursor-pointer small text-white" for="chkPoints">
+                                                Punkte
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="form-check d-flex align-items-center">
+                                            <input class="form-check-input" type="checkbox" id="chkGps" checked="@_karteShowGps"
+                                                   @onchange="() => _karteShowGps = !_karteShowGps" />
+                                            <label class="form-check-label ms-2 cursor-pointer small text-white" for="chkGps">
+                                                GPS-Tracks
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="form-check d-flex align-items-center">
+                                            <input class="form-check-input" type="checkbox" id="chkPhone" checked="@_karteShowPhone"
+                                                   @onchange="() => _karteShowPhone = !_karteShowPhone" />
+                                            <label class="form-check-label ms-2 cursor-pointer small text-white" for="chkPhone">
+                                                Handy-Tracks
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Rechte Spalte: Kartentyp & Gitter -->
+                        <div class="col-md-6 d-flex flex-column gap-3">
+                            <div>
+                                <label class="form-label fw-bold mb-2"><i class="bi bi-map me-1 text-warning"></i>3. Kartentyp</label>
+                                <div class="d-flex flex-column gap-2 ms-1">
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteMapType" id="tileStreets" value="streets"
+                                               checked="@(_karteTileType == "streets")"
+                                               @onchange='() => _karteTileType = "streets"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="tileStreets">
+                                            <i class="bi bi-map me-2 text-muted"></i>Straßenkarte
+                                        </label>
+                                    </div>
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteMapType" id="tileSatellite" value="satellite"
+                                               checked="@(_karteTileType == "satellite")"
+                                               @onchange='() => _karteTileType = "satellite"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="tileSatellite">
+                                            <i class="bi bi-globe me-2 text-muted"></i>Satellit (Esri)
+                                        </label>
+                                    </div>
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteMapType" id="tileSatelliteGoogle" value="satelliteGoogle"
+                                               checked="@(_karteTileType == "satelliteGoogle")"
+                                               @onchange='() => _karteTileType = "satelliteGoogle"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="tileSatelliteGoogle">
+                                            <i class="bi bi-globe me-2 text-muted"></i>Satellit (Google)
+                                        </label>
+                                    </div>
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteMapType" id="tileHybrid" value="hybrid"
+                                               checked="@(_karteTileType == "hybrid")"
+                                               @onchange='() => _karteTileType = "hybrid"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="tileHybrid">
+                                            <i class="bi bi-globe2 me-2 text-muted"></i>Hybrid (Google)
+                                        </label>
+                                    </div>
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteMapType" id="tileTopo" value="topo"
+                                               checked="@(_karteTileType == "topo")"
+                                               @onchange='() => _karteTileType = "topo"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="tileTopo">
+                                            <i class="bi bi-bar-chart-steps me-2 text-muted"></i>Topografisch
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label class="form-label fw-bold mb-2"><i class="bi bi-grid-3x3 me-1 text-warning"></i>4. Koordinaten-Gitter</label>
+                                <div class="d-flex flex-column gap-2 ms-1">
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteGridType" id="gridNone" value="none"
+                                               checked="@(_karteGridType == "none")"
+                                               @onchange='() => _karteGridType = "none"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="gridNone">
+                                            <i class="bi bi-slash-circle me-2 text-muted"></i>Ohne Gitter
+                                        </label>
+                                    </div>
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteGridType" id="gridUtm" value="utm"
+                                               checked="@(_karteGridType == "utm")"
+                                               @onchange='() => _karteGridType = "utm"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="gridUtm">
+                                            <i class="bi bi-grid me-2 text-muted"></i>UTM-Gitter
+                                        </label>
+                                    </div>
+                                    <div class="form-check d-flex align-items-center">
+                                        <input class="form-check-input" type="radio" name="karteGridType" id="gridLatLon" value="latlon"
+                                               checked="@(_karteGridType == "latlon")"
+                                               @onchange='() => _karteGridType = "latlon"' />
+                                        <label class="form-check-label ms-2 cursor-pointer small d-flex align-items-center text-white" for="gridLatLon">
+                                            <i class="bi bi-grid-3x3 me-2 text-muted"></i>Breitengrad / Längengrad
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
@@ -3,6 +3,7 @@ using Einsatzueberwachung.Domain.Models;
 using Einsatzueberwachung.Domain.Models.Enums;
 using Einsatzueberwachung.Domain.Services;
 using Einsatzueberwachung.Server.Components.Pages.KarteComponents;
+using Einsatzueberwachung.Server.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
@@ -17,6 +18,7 @@ public partial class EinsatzKarte
     [Inject] IJSRuntime JSRuntime { get; set; } = default!;
     [Inject] NavigationManager Navigation { get; set; } = default!;
     [Inject] ILogger<EinsatzKarte> Logger { get; set; } = default!;
+    [Inject] MissionTopbarService MissionTopbar { get; set; } = default!;
 
     [SupplyParameterFromQuery(Name = "embed")]
     private bool _embedMode { get; set; }
@@ -39,6 +41,8 @@ public partial class EinsatzKarte
     private bool _showDialog = false;
     private bool _showKarteDialog = false;
     private string _karteTileType = "streets";
+    private string _mapBaseLayerType = "streets";
+    private string _gridLayerType = "none";
     private string _karteTeamFilter = "";
     private SearchArea _currentArea = new();
     private SearchArea? _editingArea = null;
@@ -82,6 +86,8 @@ public partial class EinsatzKarte
     private List<Collar> _collars = new();
     private bool _trackingVisible = false;
     private bool _phoneLayerVisible = false;
+    private bool _searchAreasVisible = true;
+    private bool _pointMarkersVisible = true;
     private Dictionary<string, string> _oobWarnings = new();
     private Dictionary<string, CollarLocation> _collarLastLocations = new();
 
@@ -111,9 +117,30 @@ public partial class EinsatzKarte
 
     // Zeichenmodus (Suchgebiete)
     private bool _drawingActive = false;
+    private bool _mapTileMenuExpanded;
+    private bool _mapGridMenuExpanded;
+    private bool _mapContentMenuExpanded = true;
 
     // Referenz auf KartePunkteTab für JSInvokable-Callbacks
     private KartePunkteTab? _punkteTab;
+
+    private string SelectedMapLayerLabel => _mapBaseLayerType switch
+    {
+        "satellite" => "Satellit (Esri)",
+        "satelliteGoogle" => "Satellit (Google)",
+        "hybrid" => "Hybrid (Google)",
+        "topo" => "Topografisch",
+        _ => "Straßenkarte"
+    };
+
+    private string SelectedGridLayerLabel => _gridLayerType switch
+    {
+        "utm" => "UTM",
+        "latlon" => "Lat/Lon",
+        _ => "Ohne"
+    };
+
+    private string MapContentSummary => $"{(_searchAreasVisible ? 1 : 0) + (_pointMarkersVisible ? 1 : 0) + (_trackingVisible ? 1 : 0) + (_phoneLayerVisible ? 1 : 0)}/4 aktiv";
 
     protected override async Task OnInitializedAsync()
     {
@@ -154,6 +181,8 @@ public partial class EinsatzKarte
             _mapCenterLat = elw.Latitude;
             _mapCenterLng = elw.Longitude;
         }
+
+        ConfigureMissionTopbarContent();
     }
 
     protected override void OnParametersSet()
@@ -798,9 +827,86 @@ public partial class EinsatzKarte
 
     private async Task SetEmbedTileType(string type)
     {
-        _karteTileType = type;
+        _mapBaseLayerType = type;
         try { await JSRuntime.InvokeVoidAsync("LeafletMap.changeBaseLayer", "einsatzMap", type); }
         catch (Exception ex) { Logger.LogWarning(ex, "changeBaseLayer fehlgeschlagen"); }
+    }
+
+    private Task OnTopbarSearchTextChanged(string value)
+    {
+        _addressSearch = value;
+        return Task.CompletedTask;
+    }
+
+    private void ConfigureMissionTopbarContent()
+    {
+        MissionTopbar.SetContent(this, builder =>
+        {
+            builder.OpenComponent<KarteTopbarSearch>(0);
+            builder.AddAttribute(1, nameof(KarteTopbarSearch.SearchText), _addressSearch);
+            builder.AddAttribute(2, nameof(KarteTopbarSearch.SearchTextChanged), EventCallback.Factory.Create<string>(this, OnTopbarSearchTextChanged));
+            builder.AddAttribute(3, nameof(KarteTopbarSearch.OnSearch), EventCallback.Factory.Create(this, SearchAddress));
+            builder.CloseComponent();
+        });
+    }
+
+    private async Task ChangeMapBaseLayerAsync(string type)
+    {
+        await SetEmbedTileType(type);
+    }
+
+    private async Task ChangeGridLayerAsync(string type)
+    {
+        _gridLayerType = type;
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("LeafletMap.changeGridLayer", "einsatzMap", type);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "changeGridLayer fehlgeschlagen");
+        }
+    }
+
+    private async Task ToggleSearchAreasVisibility()
+    {
+        _searchAreasVisible = !_searchAreasVisible;
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("LeafletMap.toggleSearchAreas", "einsatzMap", _searchAreasVisible);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "toggleSearchAreas fehlgeschlagen");
+        }
+    }
+
+    private async Task TogglePointMarkersVisibility()
+    {
+        _pointMarkersVisible = !_pointMarkersVisible;
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("LeafletMap.toggleCoordinateMarkers", "einsatzMap", _pointMarkersVisible);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "toggleCoordinateMarkers fehlgeschlagen");
+        }
+    }
+
+    private void ToggleTileMenu()
+    {
+        _mapTileMenuExpanded = !_mapTileMenuExpanded;
+    }
+
+    private void ToggleGridMenu()
+    {
+        _mapGridMenuExpanded = !_mapGridMenuExpanded;
+    }
+
+    private void ToggleMapContentMenu()
+    {
+        _mapContentMenuExpanded = !_mapContentMenuExpanded;
     }
 
     private async Task RecenterMap()
@@ -1333,6 +1439,7 @@ public partial class EinsatzKarte
     {
         try
         {
+            MissionTopbar.ClearContent(this);
             CollarTrackingService.CollarLocationReceived -= OnCollarLocationReceived;
             CollarTrackingService.OutOfBoundsDetected -= OnOutOfBoundsDetected;
             CollarTrackingService.CollarHistoryCleared -= OnCollarHistoryCleared;

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
@@ -605,6 +605,11 @@ public partial class EinsatzKarte
         Navigation.NavigateTo("/einsatz-monitor");
     }
 
+    private void NavigateToTeamInMonitor(string teamId)
+    {
+        Navigation.NavigateTo($"/einsatz-monitor?scrollToTeam={teamId}");
+    }
+
     private async Task SetElwPosition()
     {
         try

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
@@ -40,10 +40,19 @@ public partial class EinsatzKarte
     private List<Team> _teams = new();
     private bool _showDialog = false;
     private bool _showKarteDialog = false;
+    private string _karteZoomMode = "all";
+    private double? _liveMapCenterLat;
+    private double? _liveMapCenterLng;
+    private int? _liveMapZoom;
     private string _karteTileType = "streets";
+    private string _karteGridType = "none";
     private string _mapBaseLayerType = "streets";
     private string _gridLayerType = "none";
     private string _karteTeamFilter = "";
+    private bool _karteShowSearchAreas = true;
+    private bool _karteShowPoints = true;
+    private bool _karteShowGps = false;
+    private bool _karteShowPhone = false;
     private SearchArea _currentArea = new();
     private SearchArea? _editingArea = null;
     private string _selectedTeamId = "";
@@ -651,7 +660,54 @@ public partial class EinsatzKarte
     private string BuildKarteUrl()
     {
         var teamParam = string.IsNullOrWhiteSpace(_karteTeamFilter) ? "" : $"&teamId={Uri.EscapeDataString(_karteTeamFilter)}";
-        return $"/downloads/einsatz-karte.pdf?mapType={_karteTileType}{teamParam}";
+        var showAreas = _karteShowSearchAreas ? "" : "&showSearchAreas=false";
+        var showPoints = _karteShowPoints ? "" : "&showPoints=false";
+        var showGps = _karteShowGps ? "&showGps=true" : "";
+        var showPhone = _karteShowPhone ? "&showPhone=true" : "";
+        var gridType = _karteGridType != "none" ? $"&gridType={_karteGridType}" : "";
+        var zoomMode = $"&zoomMode={_karteZoomMode}";
+        var viewportParams = "";
+        if (_karteZoomMode == "viewport" && _liveMapCenterLat.HasValue && _liveMapCenterLng.HasValue && _liveMapZoom.HasValue)
+        {
+            viewportParams = $"&centerLat={_liveMapCenterLat.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}&centerLng={_liveMapCenterLng.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}&zoom={_liveMapZoom.Value}";
+        }
+        return $"/downloads/einsatz-karte.pdf?mapType={_karteTileType}{teamParam}{showAreas}{showPoints}{showGps}{showPhone}{gridType}{zoomMode}{viewportParams}";
+    }
+
+    private async Task OpenPrintDialogAsync()
+    {
+        try
+        {
+            var viewport = await JSRuntime.InvokeAsync<MapViewport>("LeafletMap.getMapViewport", "einsatzMap");
+            _liveMapCenterLat = viewport.Lat;
+            _liveMapCenterLng = viewport.Lng;
+            _liveMapZoom = viewport.Zoom;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Fehler beim Abrufen des Viewports");
+        }
+        _showKarteDialog = true;
+    }
+
+    private void SyncPrintDialogFromMap()
+    {
+        _karteTileType = _mapBaseLayerType;
+        _karteGridType = _gridLayerType;
+        _karteShowSearchAreas = _searchAreasVisible;
+        _karteShowPoints = _pointMarkersVisible;
+        _karteShowGps = _trackingVisible;
+        _karteShowPhone = _phoneLayerVisible;
+        _karteZoomMode = "viewport";
+    }
+
+    private void HandleTeamFilterChanged(ChangeEventArgs e)
+    {
+        _karteTeamFilter = e.Value?.ToString() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(_karteTeamFilter) && _karteZoomMode == "team")
+        {
+            _karteZoomMode = "all";
+        }
     }
 
     // Draw-Modi aktivieren
@@ -902,16 +958,31 @@ public partial class EinsatzKarte
     private void ToggleTileMenu()
     {
         _mapTileMenuExpanded = !_mapTileMenuExpanded;
+        if (_mapTileMenuExpanded)
+        {
+            _mapGridMenuExpanded = false;
+            _mapContentMenuExpanded = false;
+        }
     }
 
     private void ToggleGridMenu()
     {
         _mapGridMenuExpanded = !_mapGridMenuExpanded;
+        if (_mapGridMenuExpanded)
+        {
+            _mapTileMenuExpanded = false;
+            _mapContentMenuExpanded = false;
+        }
     }
 
     private void ToggleMapContentMenu()
     {
         _mapContentMenuExpanded = !_mapContentMenuExpanded;
+        if (_mapContentMenuExpanded)
+        {
+            _mapTileMenuExpanded = false;
+            _mapGridMenuExpanded = false;
+        }
     }
 
     private async Task RecenterMap()
@@ -1476,5 +1547,13 @@ public partial class EinsatzKarte
     {
         public double Lat { get; set; }
         public double Lng { get; set; }
+    }
+
+    // Helper-Klasse für Map-Viewport
+    private class MapViewport
+    {
+        public double Lat { get; set; }
+        public double Lng { get; set; }
+        public int Zoom { get; set; }
     }
 }

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteGebieteTab.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteGebieteTab.razor
@@ -40,6 +40,12 @@
                     <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnZoomToArea.InvokeAsync(area)" title="Zoomen">
                         <i class="bi bi-zoom-in"></i>
                     </button>
+                    @if (!string.IsNullOrEmpty(area.AssignedTeamId))
+                    {
+                        <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnNavigateToTeam.InvokeAsync(area.AssignedTeamId)" title="Zum Team im Monitor">
+                            <i class="bi bi-people"></i>
+                        </button>
+                    }
                     <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnEdit.InvokeAsync(area)" title="Bearbeiten">
                         <i class="bi bi-pencil"></i>
                     </button>
@@ -70,4 +76,5 @@ else
     [Parameter] public EventCallback<SearchArea> OnEdit { get; set; }
     [Parameter] public EventCallback<SearchArea> OnDownloadGpx { get; set; }
     [Parameter] public EventCallback<SearchArea> OnDelete { get; set; }
+    [Parameter] public EventCallback<string> OnNavigateToTeam { get; set; }
 }

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteGpsTab.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteGpsTab.razor
@@ -37,39 +37,49 @@
         @foreach (var collar in Collars)
         {
             CollarLastLocations.TryGetValue(collar.Id, out var lastLoc);
-            <button type="button"
-                    class="collar-item"
-                    @onclick="() => OnZoomToCollar.InvokeAsync(collar)"
-                    title="Zum Live-Punkt springen">
-                <div class="collar-head-row">
-                    <span class="collar-name">
-                        <i class="bi bi-geo-alt-fill" style="color: @GetCollarColorFn(collar.Id);"></i>
-                        @collar.CollarName [@collar.Id]
-                    </span>
+            <div class="sidebar-card-item"
+                 role="button"
+                 tabindex="0"
+                 title="Zum Live-Punkt springen"
+                 @onkeydown='async e => { if (e.Key == "Enter" || e.Key == " ") await OnZoomToCollar.InvokeAsync(collar); }'
+                 @onclick="() => OnZoomToCollar.InvokeAsync(collar)">
+                <div class="card-header-row">
+                    <i class="bi bi-geo-alt-fill card-icon" style="color: @GetCollarColorFn(collar.Id);"></i>
+                    <span class="card-title">@collar.CollarName [@collar.Id]</span>
+                </div>
+                <div class="card-info-row">
                     @if (collar.IsAssigned)
                     {
                         var liveTeam = Teams.FirstOrDefault(t => t.TeamId == collar.AssignedTeamId);
-                        <span class="collar-team text-primary">@(liveTeam?.TeamName ?? "?")</span>
+                        <small class="text-primary">@(liveTeam?.TeamName ?? "?")</small>
                     }
                     else
                     {
-                        <span class="collar-team text-muted">Nicht zugewiesen</span>
+                        <small class="text-muted">Nicht zugewiesen</small>
                     }
-                </div>
-                <div class="collar-status-line d-flex justify-content-between align-items-center">
                     @if (lastLoc != null)
                     {
                         var (icon, color) = GetBatteryDisplay(lastLoc.BatteryLevel);
-                        <span class="collar-status-pill"><i class="bi @icon @color me-1"></i>Akku</span>
-                        <span class="collar-status-pill text-muted">Letztes Update: @FormatAge(lastLoc.Timestamp)</span>
+                        <small><i class="bi @icon @color me-1"></i>Akku</small>
+                        <small class="text-muted">Update: @FormatAge(lastLoc.Timestamp)</small>
                     }
                     else
                     {
-                        <span class="collar-status-pill text-muted"><i class="bi bi-battery me-1"></i>Akku: -</span>
-                        <span class="collar-status-pill text-muted">Letztes Update: keine Daten</span>
+                        <small class="text-muted">Keine Daten</small>
                     }
                 </div>
-            </button>
+                <div class="card-actions">
+                    <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnZoomToCollar.InvokeAsync(collar)" title="Zoomen">
+                        <i class="bi bi-zoom-in"></i>
+                    </button>
+                    @if (collar.IsAssigned)
+                    {
+                        <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnNavigateToTeam.InvokeAsync(collar.AssignedTeamId!)" title="Zum Team im Monitor">
+                            <i class="bi bi-people"></i>
+                        </button>
+                    }
+                </div>
+            </div>
         }
     }
     else
@@ -112,42 +122,50 @@
                 @foreach (var snap in search.Tracks)
                 {
                     var isVisible = !CompletedTrackVisibility.TryGetValue(snap.Id, out var sv) || sv;
-                    <div class="snapshot-item ms-2">
-                            <div class="snapshot-summary"
-                                role="button"
-                                tabindex="0"
-                                @onclick="() => OnZoomToTrack.InvokeAsync(snap.Id)"
-                                @onkeydown='async e => { if (e.Key == "Enter" || e.Key == " ") await OnZoomToTrack.InvokeAsync(snap.Id); }'
-                                title="Auf Karte anzeigen">
-                            <span class="snapshot-color-bar" style="background:@snap.Color"></span>
-                            <div class="snapshot-meta">
-                                <div class="snapshot-sub">
-                                    @if (snap.TrackType == TrackType.HumanTrack)
-                                    {
-                                        <span class="badge bg-info text-dark badge-xs me-1" title="Mensch-Laufweg"><i class="bi bi-person-walking"></i></span>
-                                    }
-                                    else
-                                    {
-                                        <span class="badge bg-primary badge-xs me-1" title="Halsband-Track"><i class="bi bi-broadcast"></i></span>
-                                    }
-                                    @snap.DisplayLabel
-                                </div>
-                                <div class="snapshot-sub">@snap.FormattedDuration · @snap.FormattedDistance · @snap.Points.Count Pkt.</div>
-                            </div>
-                            <div class="snapshot-controls">
-                                <button class="btn btn-xs @(isVisible ? "btn-outline-secondary" : "btn-outline-secondary opacity-50")"
-                                        title="@(isVisible ? "Auf Karte ausblenden" : "Auf Karte einblenden")"
-                                        @onclick:stopPropagation="true"
-                                        @onclick="() => OnToggleTrackVisibility.InvokeAsync((snap.Id, !isVisible))">
-                                    <i class="bi @(isVisible ? "bi-eye" : "bi-eye-slash")"></i>
+                    <div class="sidebar-card-item"
+                         role="button"
+                         tabindex="0"
+                         title="Auf Karte anzeigen"
+                         @onkeydown='async e => { if (e.Key == "Enter" || e.Key == " ") await OnZoomToTrack.InvokeAsync(snap.Id); }'
+                         @onclick="() => OnZoomToTrack.InvokeAsync(snap.Id)">
+                        <div class="card-header-row">
+                            @if (snap.TrackType == TrackType.HumanTrack)
+                            {
+                                <i class="bi bi-person-walking card-icon" style="color: @snap.Color;" title="Mensch-Laufweg"></i>
+                            }
+                            else
+                            {
+                                <i class="bi bi-broadcast card-icon" style="color: @snap.Color;" title="Halsband-Track"></i>
+                            }
+                            <span class="card-title">@snap.DisplayLabel</span>
+                        </div>
+                        <div class="card-info-row">
+                            <small>@snap.FormattedDuration</small>
+                            <small>@snap.FormattedDistance</small>
+                            <small class="text-muted">@snap.Points.Count Pkt.</small>
+                        </div>
+                        <div class="card-actions">
+                            <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnZoomToTrack.InvokeAsync(snap.Id)" title="Zoomen">
+                                <i class="bi bi-zoom-in"></i>
+                            </button>
+                            @if (!string.IsNullOrEmpty(snap.TeamId))
+                            {
+                                <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnNavigateToTeam.InvokeAsync(snap.TeamId)" title="Zum Team im Monitor">
+                                    <i class="bi bi-people"></i>
                                 </button>
-                                <button class="btn btn-xs btn-outline-secondary"
-                                        title="Details anzeigen"
-                                        @onclick:stopPropagation="true"
-                                        @onclick="() => OpenDetailPopup(snap)">
-                                    <i class="bi bi-info-circle"></i>
-                                </button>
-                            </div>
+                            }
+                            <button class="btn btn-xs btn-link @(isVisible ? "" : "opacity-50")"
+                                    title="@(isVisible ? "Auf Karte ausblenden" : "Auf Karte einblenden")"
+                                    @onclick:stopPropagation="true"
+                                    @onclick="() => OnToggleTrackVisibility.InvokeAsync((snap.Id, !isVisible))">
+                                <i class="bi @(isVisible ? "bi-eye" : "bi-eye-slash")"></i>
+                            </button>
+                            <button class="btn btn-xs btn-link"
+                                    title="Details anzeigen"
+                                    @onclick:stopPropagation="true"
+                                    @onclick="() => OpenDetailPopup(snap)">
+                                <i class="bi bi-info-circle"></i>
+                            </button>
                         </div>
                     </div>
                 }
@@ -566,6 +584,7 @@
     [Parameter] public EventCallback<string> OnZoomToTrack { get; set; }
     [Parameter] public EventCallback<(string Id, bool Visible)> OnToggleTrackVisibility { get; set; }
     [Parameter] public EventCallback<GpxImportRequest> OnGpxImported { get; set; }
+    [Parameter] public EventCallback<string> OnNavigateToTeam { get; set; }
     [Parameter] public Dictionary<string, CollarLocation> CollarLastLocations { get; set; } = new();
 
     /// <summary>Datenpaket, das beim Bestätigen des Import-Dialogs gesendet wird.</summary>

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteGpsTab.razor.css
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteGpsTab.razor.css
@@ -100,6 +100,14 @@
     margin-bottom: 0;
 }
 
+.completed-search-group .sidebar-card-item {
+    border: none;
+    border-top: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0;
+    margin-bottom: 0;
+    box-shadow: none;
+}
+
 /* ========================================
    Abgeschlossene Suchen – Snapshot Items
    ======================================== */

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteHandyTab.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteHandyTab.razor
@@ -36,35 +36,49 @@
             var histCount = history?.Count ?? 0;
             var histDist = history != null ? ComputeDistance(history) : 0.0;
 
-            <button type="button"
-                    class="collar-item"
-                    @onclick="() => OnZoomToTeam.InvokeAsync(teamId)"
-                    title="Zum Standort springen">
-                <div class="collar-head-row">
-                    <span class="collar-name">
-                        <i class="bi bi-person-fill" style="color: @GetTeamPhoneColor(teamId);"></i>
-                        @teamName
-                    </span>
-                    @if (loc?.Accuracy.HasValue == true)
-                    {
-                        <span class="collar-team text-muted" style="font-size:0.7rem;">&#177;@((int)loc.Accuracy!.Value) m</span>
-                    }
+            <div class="sidebar-card-item"
+                 role="button"
+                 tabindex="0"
+                 title="Zum Standort springen"
+                 @onkeydown='async e => { if (e.Key == "Enter" || e.Key == " ") await OnZoomToTeam.InvokeAsync(teamId); }'
+                 @onclick="() => OnZoomToTeam.InvokeAsync(teamId)">
+                <div class="card-header-row">
+                    <i class="bi bi-person-fill card-icon" style="color: @GetTeamPhoneColor(teamId);"></i>
+                    <span class="card-title">@teamName</span>
                 </div>
-                <div class="collar-status-line d-flex justify-content-between align-items-center">
+                <div class="card-info-row">
                     @if (loc != null)
                     {
-                        <span class="collar-status-pill text-muted">Letztes Update: @FormatAge(loc.Timestamp)</span>
+                        <small>Letztes Update: @FormatAge(loc.Timestamp)</small>
                     }
                     else
                     {
-                        <span class="collar-status-pill text-muted">Keine Live-Position</span>
+                        <small class="text-muted">Keine Live-Position</small>
+                    }
+                    @if (loc?.Accuracy.HasValue == true)
+                    {
+                        <small class="text-muted">&#177;@((int)loc.Accuracy!.Value) m</small>
                     }
                     @if (histCount > 0)
                     {
-                        <span class="collar-status-pill text-muted">@FormatDistance(histDist) &middot; @histCount Pkt.</span>
+                        <small class="text-muted">@FormatDistance(histDist) &middot; @histCount Pkt.</small>
                     }
                 </div>
-            </button>
+                <div class="card-actions">
+                    <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnZoomToTeam.InvokeAsync(teamId)" title="Zum Standort zoomen">
+                        <i class="bi bi-zoom-in"></i>
+                    </button>
+                    <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => OnNavigateToTeam.InvokeAsync(teamId)" title="Zum Team im Monitor">
+                        <i class="bi bi-people"></i>
+                    </button>
+                    <button class="btn btn-xs btn-link @(PhoneLayerVisible ? "" : "opacity-50")"
+                            @onclick:stopPropagation="true"
+                            @onclick="OnTogglePhoneLayer"
+                            title="@(PhoneLayerVisible ? "Handy-Layer ausblenden" : "Handy-Layer einblenden")">
+                        <i class="bi @(PhoneLayerVisible ? "bi-eye" : "bi-eye-slash")"></i>
+                    </button>
+                </div>
+            </div>
         }
     }
     else
@@ -82,6 +96,7 @@
     [Parameter] public bool PhoneLayerVisible { get; set; }
     [Parameter] public EventCallback<string> OnZoomToTeam { get; set; }
     [Parameter] public EventCallback OnTogglePhoneLayer { get; set; }
+    [Parameter] public EventCallback<string> OnNavigateToTeam { get; set; }
 
     private PeriodicTimer? _ageRefreshTimer;
     private CancellationTokenSource? _timerCts;

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KartePunkteTab.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KartePunkteTab.razor
@@ -3,6 +3,11 @@
 <div class="sidebar-content-header">
     <span class="small fw-semibold text-muted"><i class="bi bi-crosshair me-1"></i>Punkte</span>
     <div class="d-flex gap-1 align-items-center">
+        <button class="btn btn-xs btn-outline-secondary"
+                @onclick="() => OnSetElwPosition.InvokeAsync()"
+                title="@(HasElwPosition ? "ELW verschieben" : "ELW setzen")">
+            <i class="bi bi-geo-fill">ELW</i>
+        </button>
         @if (Markers.Any())
         {
             <button class="btn btn-xs btn-link p-0" @onclick="DownloadAllMarkersGpx" title="Alle als GPX exportieren">
@@ -216,4 +221,3 @@
         </div>
     </div>
 }
-

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KartePunkteTab.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KartePunkteTab.razor
@@ -114,26 +114,34 @@
         <div class="marker-list">
             @foreach (var marker in Markers.OrderByDescending(m => m.CreatedAt))
             {
-                <div class="marker-list-item">
-                    <button type="button" class="marker-list-info" @onclick="() => ZoomToMarker(marker)" title="Zum Punkt zoomen">
-                        <span class="marker-list-label">
-                            <i class="bi bi-pin-map-fill" style="color: @marker.Color;"></i>
-                            @(string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label)
-                        </span>
-                        <span class="marker-list-coords text-muted">@marker.FormattedLatLng</span>
+                <div class="sidebar-card-item"
+                     role="button"
+                     tabindex="0"
+                     title="Zum Punkt zoomen"
+                     @onkeydown='async e => { if (e.Key == "Enter" || e.Key == " ") await ZoomToMarker(marker); }'
+                     @onclick="() => ZoomToMarker(marker)">
+                    <div class="card-header-row">
+                        <i class="bi bi-pin-map-fill card-icon" style="color: @marker.Color;"></i>
+                        <span class="card-title">@(string.IsNullOrEmpty(marker.Label) ? $"Punkt {marker.FormattedTimestamp}" : marker.Label)</span>
+                    </div>
+                    <div class="card-info-row">
+                        <small class="text-muted">@marker.FormattedLatLng</small>
                         @if (!string.IsNullOrEmpty(marker.FormattedUtm))
                         {
-                            <span class="marker-list-coords text-muted">@marker.FormattedUtm</span>
+                            <small class="text-muted">@marker.FormattedUtm</small>
                         }
-                    </button>
-                    <div class="marker-list-actions">
-                        <button class="btn btn-xs btn-link p-0" @onclick="() => StartEditMarker(marker)" title="Bearbeiten">
+                    </div>
+                    <div class="card-actions">
+                        <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => ZoomToMarker(marker)" title="Zoomen">
+                            <i class="bi bi-zoom-in"></i>
+                        </button>
+                        <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => StartEditMarker(marker)" title="Bearbeiten">
                             <i class="bi bi-pencil"></i>
                         </button>
-                        <button class="btn btn-xs btn-link p-0" @onclick="() => DownloadMarkerGpx(marker)" title="GPX">
+                        <button class="btn btn-xs btn-link" @onclick:stopPropagation="true" @onclick="() => DownloadMarkerGpx(marker)" title="GPX">
                             <i class="bi bi-download"></i>
                         </button>
-                        <button class="btn btn-xs btn-link text-secondary p-0" @onclick="() => RemoveMarker(marker)" title="Entfernen">
+                        <button class="btn btn-xs btn-link text-secondary" @onclick:stopPropagation="true" @onclick="() => RemoveMarker(marker)" title="Entfernen">
                             <i class="bi bi-trash"></i>
                         </button>
                     </div>

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KartePunkteTab.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KartePunkteTab.razor.cs
@@ -15,8 +15,10 @@ public partial class KartePunkteTab
     private const double CoordinateEpsilon = 0.0000001;
 
     [Parameter, EditorRequired] public List<MapMarker> Markers { get; set; } = new();
+    [Parameter] public bool HasElwPosition { get; set; }
     [Parameter] public bool ClickToPlaceActive { get; set; }
     [Parameter] public string CoordInputMode { get; set; } = "click";
+    [Parameter] public EventCallback OnSetElwPosition { get; set; }
     [Parameter] public EventCallback<string> CoordInputModeChanged { get; set; }
     [Parameter] public EventCallback OnActivateClickToPlace { get; set; }
     [Parameter] public EventCallback OnDeactivateClickToPlace { get; set; }

--- a/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteTopbarSearch.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/KarteComponents/KarteTopbarSearch.razor
@@ -1,0 +1,38 @@
+<form class="map-topbar-search" @onsubmit="HandleSubmit" @onsubmit:preventDefault="true">
+    <div class="input-group input-group-sm map-topbar-search-input-group">
+        <input type="text"
+               class="form-control"
+               value="@_searchText"
+               @oninput="HandleInput"
+               placeholder="Ort oder Adresse suchen"
+               aria-label="Kartensuche" />
+        <button class="btn btn-primary" type="submit" aria-label="Kartensuche ausführen">
+            <i class="bi bi-pin-map"></i>
+        </button>
+    </div>
+</form>
+
+@code {
+    [Parameter] public string SearchText { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> SearchTextChanged { get; set; }
+    [Parameter] public EventCallback OnSearch { get; set; }
+
+    private string _searchText = string.Empty;
+
+    protected override void OnParametersSet()
+    {
+        _searchText = SearchText ?? string.Empty;
+    }
+
+    private async Task HandleInput(ChangeEventArgs args)
+    {
+        _searchText = args.Value?.ToString() ?? string.Empty;
+        await SearchTextChanged.InvokeAsync(_searchText);
+    }
+
+    private async Task HandleSubmit()
+    {
+        await SearchTextChanged.InvokeAsync(_searchText);
+        await OnSearch.InvokeAsync();
+    }
+}

--- a/src/Einsatzueberwachung.Server/Extensions/DownloadEndpoints.cs
+++ b/src/Einsatzueberwachung.Server/Extensions/DownloadEndpoints.cs
@@ -28,23 +28,92 @@ internal static class DownloadEndpoints
         app.MapGet("/downloads/einsatz-karte.pdf", async (
             IEinsatzService einsatzService,
             IPdfExportService pdfExportService,
+            ICollarTrackingService collarTrackingService,
             ILoggerFactory loggerFactory,
             string? mapType = null,
-            string? teamId = null) =>
+            string? teamId = null,
+            bool? showSearchAreas = null,
+            bool? showPoints = null,
+            bool? showGps = null,
+            bool? showPhone = null,
+            string? gridType = null,
+            string? zoomMode = null,
+            double? centerLat = null,
+            double? centerLng = null,
+            int? zoom = null) =>
         {
             var tileType = mapType switch
             {
                 "satellite" => Einsatzueberwachung.Domain.Models.Enums.MapTileType.Satellite,
+                "satelliteGoogle" => Einsatzueberwachung.Domain.Models.Enums.MapTileType.SatelliteGoogle,
+                "hybrid" => Einsatzueberwachung.Domain.Models.Enums.MapTileType.Hybrid,
                 "topo" => Einsatzueberwachung.Domain.Models.Enums.MapTileType.Topographic,
                 _ => Einsatzueberwachung.Domain.Models.Enums.MapTileType.Streets
             };
 
+            var options = new Einsatzueberwachung.Domain.Models.MapPrintOptions
+            {
+                TileType = tileType,
+                FilterTeamId = teamId,
+                ShowSearchAreas = showSearchAreas ?? true,
+                ShowPointMarkers = showPoints ?? true,
+                ShowGpsTracks = showGps ?? false,
+                ShowPhoneTracks = showPhone ?? false,
+                GridType = gridType is "utm" or "latlon" ? gridType : "none",
+                ZoomMode = zoomMode ?? "all",
+                CenterLat = centerLat,
+                CenterLng = centerLng,
+                ZoomLevel = zoom
+            };
+
             var einsatz = einsatzService.CurrentEinsatz;
+
+            // Collect GPS tracks if requested
+            List<Einsatzueberwachung.Domain.Models.TeamTrackSnapshot>? gpsTracks = null;
+            if (options.ShowGpsTracks)
+            {
+                gpsTracks = new List<Einsatzueberwachung.Domain.Models.TeamTrackSnapshot>();
+                // Add completed track snapshots
+                if (einsatz.TrackSnapshots?.Count > 0)
+                    gpsTracks.AddRange(einsatz.TrackSnapshots.Where(t => t.Points.Count >= 2));
+                // Add live collar histories
+                foreach (var collar in collarTrackingService.Collars)
+                {
+                    var history = collarTrackingService.GetLocationHistory(collar.Id);
+                    if (history.Count >= 2)
+                    {
+                        var matchingTeam = einsatzService.Teams.FirstOrDefault(t => t.CollarId == collar.Id);
+                        gpsTracks.Add(new Einsatzueberwachung.Domain.Models.TeamTrackSnapshot
+                        {
+                            TeamId = matchingTeam?.TeamId ?? string.Empty,
+                            TeamName = collar.CollarName ?? collar.Id,
+                            CollarName = collar.CollarName ?? collar.Id,
+                            Color = "#FF5722",
+                            Points = history.Select(h => new Einsatzueberwachung.Domain.Models.TrackPoint
+                            {
+                                Latitude = h.Latitude,
+                                Longitude = h.Longitude,
+                                Timestamp = h.Timestamp
+                            }).ToList()
+                        });
+                    }
+                }
+            }
+
+            // Collect phone track histories if requested
+            Dictionary<string, List<Einsatzueberwachung.Domain.Models.TeamPhoneLocation>>? phoneHistories = null;
+            if (options.ShowPhoneTracks)
+            {
+                phoneHistories = einsatzService.GetAllPhoneTrackHistories()
+                    .Where(kvp => kvp.Value.Count >= 2)
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList());
+            }
+
             byte[] bytes;
             try
             {
                 bytes = await pdfExportService.ExportEinsatzKarteToPdfBytesAsync(
-                    einsatz, einsatzService.Teams, tileType, teamId);
+                    einsatz, einsatzService.Teams, options, gpsTracks, phoneHistories);
             }
             catch (Exception ex)
             {

--- a/src/Einsatzueberwachung.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Einsatzueberwachung.Server/Extensions/ServiceCollectionExtensions.cs
@@ -264,6 +264,7 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton<ToastService>();
         services.AddSingleton<IWarningService, WarningService>();
         services.AddSingleton<IHomeNotesService, HomeNotesService>();
+        services.AddScoped<MissionTopbarService>();
         services.AddScoped<BrowserPreferencesService>();
         services.AddScoped<IRadioService, RadioService>();
 

--- a/src/Einsatzueberwachung.Server/Services/MissionTopbarService.cs
+++ b/src/Einsatzueberwachung.Server/Services/MissionTopbarService.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Components;
+
+namespace Einsatzueberwachung.Server.Services;
+
+public sealed class MissionTopbarService
+{
+    public event Action? Changed;
+
+    public RenderFragment? Content { get; private set; }
+
+    private object? _owner;
+
+    public void SetContent(object owner, RenderFragment? content)
+    {
+        _owner = owner;
+        Content = content;
+        var changed = Changed;
+        changed?.Invoke();
+    }
+
+    public void ClearContent(object owner)
+    {
+        if (!ReferenceEquals(_owner, owner))
+        {
+            return;
+        }
+
+        _owner = null;
+        Content = null;
+        var changed = Changed;
+        changed?.Invoke();
+    }
+}

--- a/src/Einsatzueberwachung.Server/Services/OsmStaticMapRenderer.CombinedMap.cs
+++ b/src/Einsatzueberwachung.Server/Services/OsmStaticMapRenderer.CombinedMap.cs
@@ -281,4 +281,315 @@ public sealed partial class OsmStaticMapRenderer
             _globalRenderLock.Release();
         }
     }
+
+    public async Task<byte[]?> RenderSearchAreaMapAsync(
+        List<SearchArea> searchAreas,
+        (double Latitude, double Longitude)? elwPosition,
+        MapPrintOptions options,
+        List<MapMarker>? markers = null,
+        List<TeamTrackSnapshot>? gpsTracks = null,
+        Dictionary<string, List<TeamPhoneLocation>>? phoneTrackHistories = null,
+        List<Team>? teams = null,
+        int width = 1500,
+        int height = 1060)
+    {
+        var validAreas = options.ShowSearchAreas
+            ? searchAreas.Where(a => a.Coordinates?.Count >= 3).ToList()
+            : new List<SearchArea>();
+        var validMarkers = options.ShowPointMarkers ? (markers ?? new List<MapMarker>()) : new List<MapMarker>();
+        var validTracks = options.ShowGpsTracks ? (gpsTracks?.Where(t => t.Points.Count >= 2).ToList() ?? new List<TeamTrackSnapshot>()) : new List<TeamTrackSnapshot>();
+        var validPhoneTracks = options.ShowPhoneTracks ? (phoneTrackHistories ?? new Dictionary<string, List<TeamPhoneLocation>>()) : new Dictionary<string, List<TeamPhoneLocation>>();
+
+        // Collect all coordinate points to determine bounds (if not in viewport mode)
+        var allLats = new List<double>();
+        var allLons = new List<double>();
+
+        var isZoomTeam = options.ZoomMode == "team" && !string.IsNullOrWhiteSpace(options.FilterTeamId);
+
+        if (isZoomTeam)
+        {
+            var targetTeamId = options.FilterTeamId!;
+            foreach (var a in validAreas)
+            {
+                var belongs = a.AssignedTeamId == targetTeamId || 
+                    (!string.IsNullOrWhiteSpace(a.AssignedTeamName) && 
+                     teams != null && 
+                     teams.Any(t => t.TeamId == targetTeamId && 
+                                    string.Equals(t.TeamName, a.AssignedTeamName, StringComparison.OrdinalIgnoreCase)));
+
+                if (belongs)
+                {
+                    allLats.AddRange(a.Coordinates.Select(c => c.Latitude));
+                    allLons.AddRange(a.Coordinates.Select(c => c.Longitude));
+                }
+            }
+            foreach (var t in validTracks)
+            {
+                if (t.TeamId == targetTeamId)
+                {
+                    allLats.AddRange(t.Points.Select(p => p.Latitude));
+                    allLons.AddRange(t.Points.Select(p => p.Longitude));
+                }
+            }
+            foreach (var (teamId, history) in validPhoneTracks)
+            {
+                if (teamId == targetTeamId)
+                {
+                    allLats.AddRange(history.Select(p => p.Latitude));
+                    allLons.AddRange(history.Select(p => p.Longitude));
+                }
+            }
+        }
+
+        // Fallback to "all" if not zooming to team, or if the selected team has no content coordinates
+        if (!isZoomTeam || allLats.Count == 0)
+        {
+            foreach (var a in validAreas)
+            {
+                allLats.AddRange(a.Coordinates.Select(c => c.Latitude));
+                allLons.AddRange(a.Coordinates.Select(c => c.Longitude));
+            }
+            foreach (var m in validMarkers)
+            {
+                allLats.Add(m.Latitude);
+                allLons.Add(m.Longitude);
+            }
+            foreach (var t in validTracks)
+            {
+                allLats.AddRange(t.Points.Select(p => p.Latitude));
+                allLons.AddRange(t.Points.Select(p => p.Longitude));
+            }
+            foreach (var (_, history) in validPhoneTracks)
+            {
+                allLats.AddRange(history.Select(p => p.Latitude));
+                allLons.AddRange(history.Select(p => p.Longitude));
+            }
+            if (elwPosition.HasValue) 
+            { 
+                allLats.Add(elwPosition.Value.Latitude); 
+                allLons.Add(elwPosition.Value.Longitude); 
+            }
+        }
+
+        var tileConfig = GetSearchAreaTileConfig(options.TileType);
+        var tilePixelSize = tileConfig.PixelSize;
+
+        using var renderCts = new CancellationTokenSource(RenderTimeout);
+        var ct = renderCts.Token;
+
+        if (!await _globalRenderLock.WaitAsync(RenderTimeout))
+        {
+            _logger.LogWarning("Erweiterte Suchgebiets-Karte: globaler Render-Lock-Timeout");
+            return null;
+        }
+
+        try
+        {
+            double TileXToLon(double x, int z, int pixelSize)
+            {
+                var tileX = x / pixelSize;
+                return (tileX / (1 << z)) * 360.0 - 180.0;
+            }
+
+            double TileYToLat(double y, int z, int pixelSize)
+            {
+                var tileY = y / pixelSize;
+                var val = Math.PI * (1.0 - 2.0 * (tileY / (1 << z)));
+                var e = Math.Exp(val);
+                var sinLat = (e * e - 1.0) / (e * e + 1.0);
+                return Math.Asin(sinLat) * 180.0 / Math.PI;
+            }
+
+            double absCropLeft, absCropTop, absCropRight, absCropBottom;
+            int zoom;
+            double minLat = 0, maxLat = 0, minLon = 0, maxLon = 0;
+
+            if (options.ZoomMode == "viewport" && options.CenterLat.HasValue && options.CenterLng.HasValue && options.ZoomLevel.HasValue)
+            {
+                zoom = options.ZoomLevel.Value;
+                if (zoom < 0) zoom = 0;
+                if (zoom > 19) zoom = 19;
+
+                var centerXPixels = LonToTileXFloat(options.CenterLng.Value, zoom) * tilePixelSize;
+                var centerYPixels = LatToTileYFloat(options.CenterLat.Value, zoom) * tilePixelSize;
+
+                absCropLeft = centerXPixels - width / 2.0;
+                absCropRight = centerXPixels + width / 2.0;
+                absCropTop = centerYPixels - height / 2.0;
+                absCropBottom = centerYPixels + height / 2.0;
+            }
+            else
+            {
+                if (allLats.Count == 0) return null;
+
+                var tempMinLat = allLats.Min(); var tempMaxLat = allLats.Max();
+                var tempMinLon = allLons.Min(); var tempMaxLon = allLons.Max();
+
+                var latPad = Math.Max((tempMaxLat - tempMinLat) * 0.12, 0.002);
+                var lonPad = Math.Max((tempMaxLon - tempMinLon) * 0.12, 0.003);
+                tempMinLat -= latPad; tempMaxLat += latPad;
+                tempMinLon -= lonPad; tempMaxLon += lonPad;
+
+                zoom = CalculateZoom(tempMinLat, tempMaxLat, tempMinLon, tempMaxLon, width, height);
+
+                absCropLeft = LonToTileXFloat(tempMinLon, zoom) * tilePixelSize;
+                absCropTop = LatToTileYFloat(tempMaxLat, zoom) * tilePixelSize;
+                absCropRight = LonToTileXFloat(tempMaxLon, zoom) * tilePixelSize;
+                absCropBottom = LatToTileYFloat(tempMinLat, zoom) * tilePixelSize;
+
+                AdjustCropToAspect(ref absCropLeft, ref absCropTop, ref absCropRight, ref absCropBottom, width, height);
+            }
+
+            // Compute final lat/lon bounds corresponding to the crop area for accurate grid drawing
+            minLon = TileXToLon(absCropLeft, zoom, tilePixelSize);
+            maxLon = TileXToLon(absCropRight, zoom, tilePixelSize);
+            maxLat = TileYToLat(absCropTop, zoom, tilePixelSize);
+            minLat = TileYToLat(absCropBottom, zoom, tilePixelSize);
+
+            var minTileX = (int)Math.Floor(absCropLeft / tilePixelSize);
+            var maxTileX = (int)Math.Floor(absCropRight / tilePixelSize);
+            var minTileY = (int)Math.Floor(absCropTop / tilePixelSize);
+            var maxTileY = (int)Math.Floor(absCropBottom / tilePixelSize);
+
+            var tiles = await DownloadTilesWithConfigAsync(minTileX, maxTileX, minTileY, maxTileY, zoom, tileConfig.UrlTemplates, ct);
+            var (fullBitmap, _, _) = AssembleTileMosaic(tiles, minTileX, minTileY, maxTileX, maxTileY, tilePixelSize);
+
+            using (fullBitmap)
+            {
+                var cropLeft = (float)(absCropLeft - minTileX * tilePixelSize);
+                var cropTop = (float)(absCropTop - minTileY * tilePixelSize);
+                var cropRight = (float)(absCropRight - minTileX * tilePixelSize);
+                var cropBottom = (float)(absCropBottom - minTileY * tilePixelSize);
+
+                using var outputBitmap = new SKBitmap(width, height);
+                using var canvas = new SKCanvas(outputBitmap);
+                canvas.DrawBitmap(fullBitmap, new SKRect(cropLeft, cropTop, cropRight, cropBottom), new SKRect(0, 0, width, height));
+
+                var scaleX = width / (cropRight - cropLeft);
+                var scaleY = height / (cropBottom - cropTop);
+                float ToX(double lon) => ((float)((LonToTileXFloat(lon, zoom) - minTileX) * tilePixelSize) - cropLeft) * scaleX;
+                float ToY(double lat) => ((float)((LatToTileYFloat(lat, zoom) - minTileY) * tilePixelSize) - cropTop) * scaleY;
+
+                // Draw search areas (fill, then stroke, then labels)
+                foreach (var area in validAreas)
+                {
+                    var areaPoints = area.Coordinates.Select(c => new SKPoint(ToX(c.Longitude), ToY(c.Latitude))).ToArray();
+                    var color = ParseColor(string.IsNullOrWhiteSpace(area.Color) ? "#2196F3" : area.Color);
+                    using var areaPath = new SKPath();
+                    areaPath.MoveTo(areaPoints[0]);
+                    for (var i = 1; i < areaPoints.Length; i++) areaPath.LineTo(areaPoints[i]);
+                    areaPath.Close();
+                    using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = color.WithAlpha(55), IsAntialias = true };
+                    canvas.DrawPath(areaPath, fillPaint);
+                }
+                foreach (var area in validAreas)
+                {
+                    var areaPoints = area.Coordinates.Select(c => new SKPoint(ToX(c.Longitude), ToY(c.Latitude))).ToArray();
+                    var color = ParseColor(string.IsNullOrWhiteSpace(area.Color) ? "#2196F3" : area.Color);
+                    using var areaPath = new SKPath();
+                    areaPath.MoveTo(areaPoints[0]);
+                    for (var i = 1; i < areaPoints.Length; i++) areaPath.LineTo(areaPoints[i]);
+                    areaPath.Close();
+                    using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = color, StrokeWidth = 3f, IsAntialias = true };
+                    canvas.DrawPath(areaPath, strokePaint);
+                }
+                foreach (var area in validAreas)
+                {
+                    var color = ParseColor(string.IsNullOrWhiteSpace(area.Color) ? "#2196F3" : area.Color);
+                    DrawAreaLabel(canvas, new SKPoint(ToX(area.Coordinates.Average(c => c.Longitude)), ToY(area.Coordinates.Average(c => c.Latitude))), area.Name, color);
+                }
+
+                // Draw GPS tracks
+                foreach (var track in validTracks)
+                {
+                    var trackPts = track.Points.Select(p => new SKPoint(ToX(p.Longitude), ToY(p.Latitude))).ToArray();
+                    using var trackPath = new SKPath();
+                    trackPath.MoveTo(trackPts[0]);
+                    for (var i = 1; i < trackPts.Length; i++) trackPath.LineTo(trackPts[i]);
+
+                    using var shadowPaint = new SKPaint
+                    {
+                        Style = SKPaintStyle.Stroke, Color = new SKColor(0, 0, 0, 65), StrokeWidth = 6f,
+                        StrokeCap = SKStrokeCap.Round, StrokeJoin = SKStrokeJoin.Round, IsAntialias = true
+                    };
+                    canvas.DrawPath(trackPath, shadowPaint);
+
+                    using var trackPaint = new SKPaint
+                    {
+                        Style = SKPaintStyle.Stroke, Color = ParseColor(track.Color), StrokeWidth = 3.5f,
+                        StrokeCap = SKStrokeCap.Round, StrokeJoin = SKStrokeJoin.Round, IsAntialias = true
+                    };
+                    canvas.DrawPath(trackPath, trackPaint);
+                }
+
+                // Draw phone tracks
+                var phoneColors = new[] { "#4CAF50", "#FF9800", "#9C27B0", "#00BCD4", "#E91E63", "#3F51B5" };
+                var phoneColorIdx = 0;
+                var teamLookup = teams?.ToDictionary(t => t.TeamId, t => t.TeamName);
+                foreach (var (teamId, history) in validPhoneTracks)
+                {
+                    var validPoints = history.Where(p => p.Latitude != 0 || p.Longitude != 0).ToList();
+                    if (validPoints.Count < 2) continue;
+
+                    var phonePts = validPoints.Select(p => new SKPoint(ToX(p.Longitude), ToY(p.Latitude))).ToArray();
+                    using var phonePath = new SKPath();
+                    phonePath.MoveTo(phonePts[0]);
+                    for (var i = 1; i < phonePts.Length; i++) phonePath.LineTo(phonePts[i]);
+
+                    var phoneColor = phoneColors[phoneColorIdx++ % phoneColors.Length];
+                    using var phonePaint = new SKPaint
+                    {
+                        Style = SKPaintStyle.Stroke, Color = ParseColor(phoneColor), StrokeWidth = 2.5f,
+                        StrokeCap = SKStrokeCap.Round, StrokeJoin = SKStrokeJoin.Round, IsAntialias = true,
+                        PathEffect = SKPathEffect.CreateDash(new[] { 8f, 4f }, 0)
+                    };
+                    canvas.DrawPath(phonePath, phonePaint);
+
+                    // Draw team label at last point
+                    var teamName = teamLookup != null && teamLookup.TryGetValue(teamId, out var tn) ? tn : null;
+                    if (!string.IsNullOrWhiteSpace(teamName))
+                    {
+                        var lastPt = phonePts[^1];
+                        DrawMarker(canvas, lastPt, ParseColor(phoneColor), teamName);
+                    }
+                }
+
+                // Draw point markers
+                foreach (var marker in validMarkers)
+                {
+                    var markerColor = ParseColor(string.IsNullOrWhiteSpace(marker.Color) ? "#2196F3" : marker.Color);
+                    var label = string.IsNullOrWhiteSpace(marker.Label) ? "●" : marker.Label;
+                    DrawMarker(canvas, new SKPoint(ToX(marker.Longitude), ToY(marker.Latitude)), markerColor, label);
+                }
+
+                // Draw ELW marker
+                if (elwPosition.HasValue)
+                    DrawMarker(canvas, new SKPoint(ToX(elwPosition.Value.Longitude), ToY(elwPosition.Value.Latitude)), new SKColor(220, 20, 60), "ELW");
+
+                if (!string.IsNullOrEmpty(options.GridType) && options.GridType != "none")
+                    DrawGrid(canvas, ToX, ToY, minLat, maxLat, minLon, maxLon, width, height, options.GridType);
+
+                DrawNorthArrow(canvas, width, height);
+                DrawAttribution(canvas, width, height, tileConfig.Attribution);
+
+                using var image = SKImage.FromBitmap(outputBitmap);
+                using var data = image.Encode(SKEncodedImageFormat.Png, 92);
+                return data.ToArray();
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            _logger.LogWarning("Erweiterte Suchgebiets-Karte: Render-Timeout nach {Sec}s erreicht", RenderTimeout.TotalSeconds);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Fehler beim Rendern der erweiterten Suchgebiets-Karte");
+            return null;
+        }
+        finally
+        {
+            _globalRenderLock.Release();
+        }
+    }
 }

--- a/src/Einsatzueberwachung.Server/Services/OsmStaticMapRenderer.Drawing.cs
+++ b/src/Einsatzueberwachung.Server/Services/OsmStaticMapRenderer.Drawing.cs
@@ -85,6 +85,158 @@ public sealed partial class OsmStaticMapRenderer
         canvas.DrawText(attribution, attrX, attrY, SKTextAlign.Left, font, paint);
     }
 
+    private static void DrawGrid(SKCanvas canvas, Func<double, float> toX, Func<double, float> toY,
+        double minLat, double maxLat, double minLon, double maxLon, int width, int height, string gridType)
+    {
+        if (gridType == "latlon")
+            DrawLatLonGrid(canvas, toX, toY, minLat, maxLat, minLon, maxLon, width, height);
+        else if (gridType == "utm")
+            DrawUtmGrid(canvas, toX, toY, minLat, maxLat, minLon, maxLon, width, height);
+    }
+
+    private static void DrawLatLonGrid(SKCanvas canvas, Func<double, float> toX, Func<double, float> toY,
+        double minLat, double maxLat, double minLon, double maxLon, int width, int height)
+    {
+        var extent = Math.Max(maxLat - minLat, maxLon - minLon);
+        double interval = extent switch
+        {
+            > 5.0 => 1.0,
+            > 1.0 => 0.5,
+            > 0.5 => 0.1,
+            > 0.1 => 0.05,
+            > 0.05 => 0.01,
+            > 0.01 => 0.005,
+            _ => 0.001
+        };
+        int decimals = interval >= 1.0 ? 0 : interval >= 0.1 ? 1 : interval >= 0.01 ? 2 : interval >= 0.001 ? 3 : 4;
+
+        using var linePaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            Color = new SKColor(214, 51, 132, 100),
+            StrokeWidth = 1f,
+            IsAntialias = true,
+            PathEffect = SKPathEffect.CreateDash(new[] { 8f, 4f }, 0)
+        };
+        using var typeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold);
+        using var font = new SKFont(typeface, 10f);
+        using var textPaint = new SKPaint { Color = new SKColor(160, 20, 100, 220), IsAntialias = true };
+        using var bgPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(255, 255, 255, 180) };
+
+        // Horizontal lines (constant lat)
+        var firstLat = Math.Ceiling(minLat / interval) * interval;
+        for (var lat = firstLat; lat <= maxLat + interval * 0.01; lat += interval)
+        {
+            var y = toY(lat);
+            if (y < -20 || y > height + 20) continue;
+            canvas.DrawLine(0, y, width, y, linePaint);
+            var label = $"{lat.ToString($"F{decimals}")}°N";
+            font.MeasureText(label, out var lb);
+            canvas.DrawRect(3, y - lb.Height - 6, lb.Width + 8, lb.Height + 4, bgPaint);
+            canvas.DrawText(label, 7, y - 6, SKTextAlign.Left, font, textPaint);
+        }
+
+        // Vertical lines (constant lon)
+        var firstLon = Math.Ceiling(minLon / interval) * interval;
+        for (var lon = firstLon; lon <= maxLon + interval * 0.01; lon += interval)
+        {
+            var x = toX(lon);
+            if (x < -20 || x > width + 20) continue;
+            canvas.DrawLine(x, 0, x, height, linePaint);
+            var label = $"{lon.ToString($"F{decimals}")}°E";
+            font.MeasureText(label, out var lb);
+            canvas.DrawRect(x - lb.Width / 2 - 3, height - lb.Height - 9, lb.Width + 8, lb.Height + 4, bgPaint);
+            canvas.DrawText(label, x, height - 9, SKTextAlign.Center, font, textPaint);
+        }
+    }
+
+    private static void DrawUtmGrid(SKCanvas canvas, Func<double, float> toX, Func<double, float> toY,
+        double minLat, double maxLat, double minLon, double maxLon, int width, int height)
+    {
+        var centerLat = (minLat + maxLat) / 2;
+        var centerLon = (minLon + maxLon) / 2;
+        var (zone, band, centerE, centerN) = Domain.Services.UtmConverter.LatLongToUtm(centerLat, centerLon);
+
+        var (_, _, minE, _) = Domain.Services.UtmConverter.LatLongToUtm(centerLat, minLon);
+        var (_, _, maxE, _) = Domain.Services.UtmConverter.LatLongToUtm(centerLat, maxLon);
+        var (_, _, _, minN) = Domain.Services.UtmConverter.LatLongToUtm(minLat, centerLon);
+        var (_, _, _, maxN) = Domain.Services.UtmConverter.LatLongToUtm(maxLat, centerLon);
+        if (minE > maxE) (minE, maxE) = (maxE, minE);
+        if (minN > maxN) (minN, maxN) = (maxN, minN);
+
+        var extent = Math.Max(maxE - minE, maxN - minN);
+        double interval = extent switch
+        {
+            > 500000 => 100000,
+            > 100000 => 50000,
+            > 50000 => 10000,
+            > 10000 => 5000,
+            > 5000 => 1000,
+            > 1000 => 500,
+            > 500 => 100,
+            _ => 50
+        };
+
+        using var linePaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            Color = new SKColor(0, 100, 255, 100),
+            StrokeWidth = 1f,
+            IsAntialias = true,
+            PathEffect = SKPathEffect.CreateDash(new[] { 8f, 4f }, 0)
+        };
+        using var typeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold);
+        using var font = new SKFont(typeface, 10f);
+        using var textPaint = new SKPaint { Color = new SKColor(0, 60, 200, 220), IsAntialias = true };
+        using var bgPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(255, 255, 255, 180) };
+
+        string FormatE(double e) => interval switch
+        {
+            >= 1000 => $"E{(long)Math.Round(e / 1000)}km",
+            >= 100 => $"E{e / 1000:F1}km",
+            >= 10 => $"E{e / 1000:F2}km",
+            _ => $"E{(long)e}m"
+        };
+        string FormatN(double n) => interval switch
+        {
+            >= 1000 => $"N{(long)Math.Round(n / 1000)}km",
+            >= 100 => $"N{n / 1000:F1}km",
+            >= 10 => $"N{n / 1000:F2}km",
+            _ => $"N{(long)n}m"
+        };
+
+        // Easting lines (approx vertical — use centerN latitude for lon mapping)
+        // Start one interval before minE to cover grid lines just outside the padded extent
+        var firstE = Math.Ceiling((minE - interval) / interval) * interval;
+        for (var e = firstE; e <= maxE + interval; e += interval)
+        {
+            var (_, lonAtE) = Domain.Services.UtmConverter.UtmToLatLong(zone, band, e, centerN);
+            var x = toX(lonAtE);
+            if (x < -20 || x > width + 20) continue;
+            canvas.DrawLine(x, 0, x, height, linePaint);
+            var label = FormatE(e);
+            font.MeasureText(label, out var lb);
+            canvas.DrawRect(x - lb.Width / 2 - 3, height - lb.Height - 9, lb.Width + 8, lb.Height + 4, bgPaint);
+            canvas.DrawText(label, x, height - 9, SKTextAlign.Center, font, textPaint);
+        }
+
+        // Northing lines (approx horizontal — use centerLon for lat mapping)
+        // Start one interval before minN to cover grid lines just outside the padded extent
+        var firstN = Math.Ceiling((minN - interval) / interval) * interval;
+        for (var n = firstN; n <= maxN + interval; n += interval)
+        {
+            var (latAtN, _) = Domain.Services.UtmConverter.UtmToLatLong(zone, band, centerE, n);
+            var y = toY(latAtN);
+            if (y < -20 || y > height + 20) continue;
+            canvas.DrawLine(0, y, width, y, linePaint);
+            var label = FormatN(n);
+            font.MeasureText(label, out var lb);
+            canvas.DrawRect(3, y - lb.Height - 6, lb.Width + 8, lb.Height + 4, bgPaint);
+            canvas.DrawText(label, 7, y - 6, SKTextAlign.Left, font, textPaint);
+        }
+    }
+
+
     private static SKColor ParseColor(string hex)
     {
         if (string.IsNullOrWhiteSpace(hex) || hex.Length < 7)

--- a/src/Einsatzueberwachung.Server/Services/OsmStaticMapRenderer.Tiles.cs
+++ b/src/Einsatzueberwachung.Server/Services/OsmStaticMapRenderer.Tiles.cs
@@ -15,6 +15,18 @@ public sealed partial class OsmStaticMapRenderer
             256,
             "© Esri, Maxar, Earthstar Geographics"),
 
+        MapTileType.SatelliteGoogle => new(
+            ["https://mt0.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+             "https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"],
+            256,
+            "© Google"),
+
+        MapTileType.Hybrid => new(
+            ["https://mt0.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
+             "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}"],
+            256,
+            "© Google"),
+
         MapTileType.Topographic => new(
             [
                 "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",

--- a/src/Einsatzueberwachung.Server/wwwroot/css/layout.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/css/layout.css
@@ -495,6 +495,15 @@ main,
     gap: 0.45rem;
 }
 
+.mission-topbar-page-slot {
+    min-width: 0;
+    justify-self: stretch;
+}
+
+.mission-topbar-page-slot.is-empty {
+    display: none;
+}
+
 .mission-status-strip {
     display: flex;
     align-items: center;
@@ -686,6 +695,11 @@ main,
     .mission-topbar-actions {
         grid-column: 2;
         justify-self: end;
+    }
+
+    .mission-topbar-page-slot {
+        grid-column: 1 / -1;
+        order: 3;
     }
 
     .mission-topbar-clock {

--- a/src/Einsatzueberwachung.Server/wwwroot/css/layout.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/css/layout.css
@@ -475,12 +475,51 @@ main,
 .mission-topbar-clock {
     justify-self: end;
     display: flex;
+    align-items: center;
     gap: 1.2rem;
     font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
     font-variant-numeric: tabular-nums;
-    font-weight: 700;
     color: var(--ui-text);
     letter-spacing: 0.05em;
+}
+
+.mission-topbar-duration {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--ui-topbar-border);
+    padding: 0.25rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.88rem;
+    font-weight: 700;
+    color: var(--ui-text);
+}
+
+.mission-topbar-duration i {
+    font-size: 1rem;
+    opacity: 0.85;
+}
+
+.mission-topbar-time-block {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    line-height: 1.15;
+    text-align: right;
+}
+
+.mission-topbar-time-block .time-display {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--ui-text);
+}
+
+.mission-topbar-time-block .date-display {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--ui-muted);
 }
 
 /* Grüner Bottom-Glow wenn Einsatz aktiv */

--- a/src/Einsatzueberwachung.Server/wwwroot/css/map.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/css/map.css
@@ -71,9 +71,15 @@ body.map-embed-mode .map-sidebar { display: none !important; }
 body.map-embed-mode .map-page-layout { height: 100vh !important; }
 body.map-embed-mode .map-content { height: 100% !important; }
 body.map-embed-mode .map-main { width: 100% !important; flex: 1 1 auto !important; position: relative; }
+body.map-embed-mode .map-floating-controls,
+body.map-embed-mode .map-floating-action { display: none !important; }
 
 /* Eingebaute Leaflet-Layer-Auswahl in Embed verstecken — wir liefern eigene Toolbar */
 body.map-embed-mode .leaflet-control-layers { display: none !important; }
+body:not(.map-embed-mode) .map-main .leaflet-top.leaflet-right .leaflet-control-layers,
+body:not(.map-embed-mode) .map-main .leaflet-top.leaflet-right .leaflet-control-grid-selector {
+    display: none !important;
+}
 
 /* ── Embed-Toolbar (kompakte Funktisch-Steuerung) ─────────────────
    Standardmäßig komplett unsichtbar. Sichtbar nur bei body.map-embed-mode
@@ -268,6 +274,40 @@ main:has(.map-page-layout) {
 
 .search-message-close:hover {
     opacity: 1;
+}
+
+.map-topbar-search {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+}
+
+.map-topbar-search-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.45rem 0.75rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--theme-primary) 16%, var(--ui-topbar-btn-bg));
+    border: 1px solid color-mix(in srgb, var(--theme-primary) 28%, var(--ui-topbar-border));
+    color: var(--ui-text);
+    font-size: 0.82rem;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.map-topbar-search-input-group {
+    min-width: min(420px, 100%);
+}
+
+.map-topbar-search-input-group .form-control,
+.map-topbar-search-input-group .btn {
+    border-color: color-mix(in srgb, var(--ui-topbar-border) 88%, transparent);
+}
+
+.map-topbar-search-input-group .btn {
+    z-index: auto;
 }
 
 /* Main Content: Sidebar + Map */
@@ -465,6 +505,110 @@ main:has(.map-page-layout) {
     width: 100% !important;
 }
 
+.map-floating-controls {
+    position: absolute;
+    top: 0.9rem;
+    right: 1rem;
+    z-index: 420;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    align-items: flex-end;
+    pointer-events: none;
+}
+
+.map-control-panel,
+.map-floating-action {
+    pointer-events: auto;
+}
+
+.map-control-panel {
+    min-width: min(290px, calc(100vw - 6rem));
+    border-radius: 14px;
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--ui-border) 85%, transparent);
+    background: color-mix(in srgb, var(--ui-surface) 94%, transparent);
+    backdrop-filter: blur(10px);
+}
+
+.map-control-trigger {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: var(--ui-text);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.7rem 0.85rem;
+    font-size: 0.9rem;
+}
+
+.map-control-trigger-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-width: 0;
+    font-weight: 600;
+}
+
+.map-control-trigger-value {
+    color: var(--ui-muted);
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+
+.map-control-body {
+    border-top: 1px solid color-mix(in srgb, var(--ui-border) 80%, transparent);
+    padding: 0.45rem 0.6rem 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.map-control-check,
+.map-control-radio {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.45rem 0.35rem;
+    margin: 0;
+    color: var(--ui-text);
+    font-size: 0.88rem;
+    cursor: pointer;
+}
+
+.map-control-check span,
+.map-control-radio span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.map-control-check input,
+.map-control-radio input {
+    margin: 0;
+    flex-shrink: 0;
+}
+
+.map-floating-action {
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 420;
+    border: 1px solid color-mix(in srgb, var(--ui-border) 85%, transparent);
+    background: color-mix(in srgb, var(--ui-surface) 94%, transparent);
+    color: var(--ui-text);
+    border-radius: 999px;
+    padding: 0.7rem 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    backdrop-filter: blur(10px);
+}
+
 .map-wrapper {
     width: 100%;
     height: 100%;
@@ -536,14 +680,34 @@ main:has(.map-page-layout) {
     .map-sidebar.minimized {
         width: 120px;
     }
-    
-    .map-header {
-        padding: 0.5rem 1rem;
-        gap: 0.5rem;
+
+    .map-topbar-search {
+        width: 100%;
     }
-    
-    .map-header h1 {
-        font-size: 1.1rem;
+
+    .map-topbar-search-badge-text {
+        display: none;
+    }
+
+    .map-topbar-search-input-group {
+        min-width: 0;
+        width: 100%;
+    }
+
+    .map-floating-controls {
+        top: 0.75rem;
+        right: 0.75rem;
+        left: 0.75rem;
+        align-items: stretch;
+    }
+
+    .map-control-panel {
+        min-width: 0;
+    }
+
+    .map-floating-action {
+        right: 0.75rem;
+        bottom: 0.75rem;
     }
 }
 
@@ -621,6 +785,4 @@ main:has(.map-page-layout) {
 [data-bs-theme="dark"] .search-area-item .area-info small {
     color: var(--ui-muted);
 }
-
-
 

--- a/src/Einsatzueberwachung.Server/wwwroot/css/map.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/css/map.css
@@ -419,7 +419,87 @@ main:has(.map-page-layout) {
     text-align: center;
 }
 
-/* Suchgebiet Items */
+/* ========================================
+   Shared Sidebar Card Item
+   ======================================== */
+
+.sidebar-card-item {
+    background: var(--ui-surface);
+    border: 1px solid var(--ui-border);
+    border-radius: 5px;
+    padding: 0.4rem 0.55rem;
+    margin-bottom: 0.3rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.sidebar-card-item:hover {
+    border-color: var(--theme-primary-border);
+    box-shadow: 0 2px 6px color-mix(in srgb, var(--theme-primary) 15%, transparent);
+    background: var(--ui-surface-2);
+}
+
+.sidebar-card-item:focus-visible {
+    outline: 2px solid var(--theme-primary, #3b82f6);
+    outline-offset: 2px;
+}
+
+.sidebar-card-item .card-header-row {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.2rem;
+    font-weight: 600;
+    font-size: 0.85rem;
+}
+
+.sidebar-card-item .card-header-row .card-icon {
+    flex-shrink: 0;
+    font-size: 0.85rem;
+}
+
+.sidebar-card-item .card-header-row .card-title {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.sidebar-card-item .card-info-row {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    font-size: 0.78rem;
+    margin-bottom: 0.2rem;
+}
+
+.sidebar-card-item .card-info-row small {
+    display: block;
+}
+
+.sidebar-card-item .card-actions {
+    display: flex;
+    gap: 0.25rem;
+    justify-content: flex-end;
+}
+
+.sidebar-card-item .card-actions .btn-xs {
+    padding: 0;
+    font-size: 0.7rem;
+    height: 20px;
+    width: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.sidebar-card-item .card-actions .btn-xs:hover {
+    opacity: 1;
+}
+
+/* Suchgebiet Items (extends sidebar-card-item) */
 .search-area-item {
     background: var(--ui-surface);
     border: 1px solid var(--ui-border);
@@ -771,6 +851,20 @@ main:has(.map-page-layout) {
     border-color: var(--ui-blue);
 }
 
+
+[data-bs-theme="dark"] .sidebar-card-item:hover {
+    background: rgba(74, 168, 255, 0.08);
+    border-color: var(--ui-blue);
+    box-shadow: 0 2px 6px rgba(74, 168, 255, 0.15);
+}
+
+[data-bs-theme="dark"] .sidebar-card-item .card-title {
+    color: var(--ui-text);
+}
+
+[data-bs-theme="dark"] .sidebar-card-item .card-info-row small {
+    color: var(--ui-muted);
+}
 
 [data-bs-theme="dark"] .search-area-item:hover {
     background: rgba(74, 168, 255, 0.08);

--- a/src/Einsatzueberwachung.Server/wwwroot/css/map.css
+++ b/src/Einsatzueberwachung.Server/wwwroot/css/map.css
@@ -595,6 +595,9 @@ main:has(.map-page-layout) {
     gap: 0.6rem;
     align-items: flex-end;
     pointer-events: none;
+    max-height: calc(100% - 5rem);
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .map-control-panel,

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -237,6 +237,15 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             drawControl: drawControl,
             markers: {},
             dotNetReference: dotNetReference,
+            gridLayers: {
+                none: null,
+                utm: utmGridGroup,
+                latlon: latLonGrid
+            },
+            currentGridLayer: null,
+            currentGridLayerType: 'none',
+            searchAreasVisible: true,
+            coordinateMarkersVisible: true,
             layers: {
                 streets: osmLayer,
                 satellite: satelliteLayer,
@@ -590,6 +599,87 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
             return true;
         } catch (err) {
             error('Fehler beim Wechseln des Layers:', err);
+            return false;
+        }
+    },
+
+    changeGridLayer: function(mapId, layerType) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) {
+                error('Karte nicht gefunden:', mapId);
+                return false;
+            }
+
+            if (mapData.currentGridLayer) {
+                mapData.map.removeLayer(mapData.currentGridLayer);
+            }
+
+            mapData.currentGridLayer = null;
+            mapData.currentGridLayerType = layerType || 'none';
+
+            const nextLayer = mapData.gridLayers?.[mapData.currentGridLayerType];
+            if (nextLayer) {
+                nextLayer.addTo(mapData.map);
+                mapData.currentGridLayer = nextLayer;
+            }
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Wechseln des Koordinaten-Gitters:', err);
+            return false;
+        }
+    },
+
+    toggleSearchAreas: function(mapId, visible) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData || !mapData.savedAreas) return false;
+
+            mapData.searchAreasVisible = !!visible;
+
+            if (mapData.searchAreasVisible) {
+                if (!mapData.map.hasLayer(mapData.savedAreas)) {
+                    mapData.savedAreas.addTo(mapData.map);
+                }
+            } else if (mapData.map.hasLayer(mapData.savedAreas)) {
+                mapData.map.removeLayer(mapData.savedAreas);
+            }
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Umschalten der Suchgebiete:', err);
+            return false;
+        }
+    },
+
+    toggleCoordinateMarkers: function(mapId, visible) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return false;
+
+            mapData.coordinateMarkersVisible = !!visible;
+
+            Object.keys(mapData.markers)
+                .filter(key => key.startsWith('coord_'))
+                .forEach(key => {
+                    const marker = mapData.markers[key];
+                    if (!marker) {
+                        return;
+                    }
+
+                    if (mapData.coordinateMarkersVisible) {
+                        if (!mapData.map.hasLayer(marker)) {
+                            marker.addTo(mapData.map);
+                        }
+                    } else if (mapData.map.hasLayer(marker)) {
+                        mapData.map.removeLayer(marker);
+                    }
+                });
+
+            return true;
+        } catch (err) {
+            error('Fehler beim Umschalten der Punkte:', err);
             return false;
         }
     },
@@ -1293,7 +1383,11 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
                 icon: icon,
                 title: label || 'Koordinaten-Marker',
                 draggable: false
-            }).addTo(mapData.map);
+            });
+
+            if (mapData.coordinateMarkersVisible !== false) {
+                marker.addTo(mapData.map);
+            }
 
             // Popup mit Koordinaten-Info
             const utmInfo = this._latLngToUtmString(lat, lng);
@@ -1589,4 +1683,3 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
         }
     }
 };
-

--- a/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/leaflet-interop.js
@@ -1,4 +1,4 @@
-﻿// Leaflet Map Interop fuer Einsatzueberwachung
+// Leaflet Map Interop fuer Einsatzueberwachung
 // Ermoeglicht das Zeichnen und Verwalten von Suchgebieten auf einer interaktiven Karte
 // Debug-Flag - setze auf false fuer Production
 const DEBUG = false;
@@ -551,6 +551,25 @@ initialize: function(mapId, centerLat, centerLng, zoom, dotNetReference) {
         } catch (err) {
             error('Fehler beim Abrufen der Kartenmitte:', err);
             return { lat: 0, lng: 0 };
+        }
+    },
+    
+    // Gibt das aktuelle Viewport (Mitte + Zoom) zurueck
+    getMapViewport: function(mapId) {
+        try {
+            const mapData = this.maps[mapId];
+            if (!mapData) return { lat: 0, lng: 0, zoom: 13 };
+            
+            const center = mapData.map.getCenter();
+            const zoom = mapData.map.getZoom();
+            return {
+                lat: center.lat,
+                lng: center.lng,
+                zoom: zoom
+            };
+        } catch (err) {
+            error('Fehler beim Abrufen des Viewports:', err);
+            return { lat: 0, lng: 0, zoom: 13 };
         }
     },
     


### PR DESCRIPTION

<img width="1903" height="920" alt="image" src="https://github.com/user-attachments/assets/68352596-ad9d-4ea2-ba04-b4f14bea5680" />


1. Aufgeräumte Kartenansicht (Kompakteres UI)
Suche in die Topbar verschoben: Das Suchfeld wurde aus dem Hauptbereich in die Topbar verlagert, um mehr Platz für die eigentliche Karte zu schaffen.
Layer-Steuerung auf der Karte: Die Layer-Auswahl (Straßenkarte, Satellit, etc.) wurde direkt als Leaflet-Control-Panel auf der Karte platziert, statt als separates Seitenmenü.
Kompakte GPS-Tracking-Liste: Die Team-Karten und Listenelemente in der linken Sidebar für GPS-Live-Tracks wurden kompakter gestaltet, um Scrollwege auf kleineren Bildschirmen zu minimieren.
2. PDF-Druck mit Koordinaten-Gittern
Druck-Auswahl mit Gittern: Im Druck-Dialog der Karte (Einsatzkarte drucken) wurden Optionen für UTM-Gitter sowie Breitengrad / Längengrad hinzugefügt.
PDF-Generierung: Der PDF-Export berechnet und rendert nun das gewählte Koordinatengitter exakt bis an die Bildränder.
3. Polish der globalen Topbar-Uhr (Windows-Uhr-Design)
Gestapeltes Uhr-Layout: Die aktuelle Systemzeit steht nun in fetter Schrift direkt über dem Datum (analog zur Windows-Taskleisten-Uhr), anstatt alles in einer langen Zeile anzuzeigen.
Einsatzdauer-Badge: Die laufende Einsatzdauer wird links daneben als übersichtliches, abgerundetes Badge (Pille) mit eigenem Symbol (bi-clock-history) und dunklem Hintergrund dargestellt.
4. Layout-Polish im Druck-Popup
Bordüren-Bereinigung: Verschachtelte Ränder (Borders) um die Spalten sowie die einzelnen Optionen wurden entfernt, um das Design flacher und sauberer zu gestalten.
Eingabe-Skalierung: Die Checkboxen und Radio-Buttons wurden im Druck-Dialog auf eine Standardgröße von 16px skaliert (statt des touch-optimierten 24px Standards).
Ausrichtung: Mithilfe von Flexbox (align-items-center) wurden alle Radio- und Checkbox-Optionen im Popup perfekt vertikal zentriert.