### PR TITLE
Add outlined Live-Hund-Icon color modes (#38)

### DIFF
--- a/src/Einsatzueberwachung.Domain/Models/SessionData.cs
+++ b/src/Einsatzueberwachung.Domain/Models/SessionData.cs
@@ -89,10 +89,12 @@ namespace Einsatzueberwachung.Domain.Models
         public int CollarNoSignalTimeoutSeconds { get; set; }
 
         // Karten-Marker Symbole
-        // Collar: "paw" | "dog" | "bone" | "dot"
+        // Collar: "paw" | "dog" | "bone" | "dot" | "crosshairs" | "location-arrow"
         // Human:  "phone" | "person" | "person_walking" | "radio" | "dot"
         public string CollarMarkerIcon { get; set; }
         public string HumanMarkerIcon { get; set; }
+        public string CollarTrackColorMode { get; set; }
+        public string CollarMarkerColorMode { get; set; }
 
         /// <summary>Gibt den konfigurierten Collar-Marker-Icon-Typ zurück (nie null/leer).</summary>
         [System.Text.Json.Serialization.JsonIgnore]
@@ -103,6 +105,17 @@ namespace Einsatzueberwachung.Domain.Models
         [System.Text.Json.Serialization.JsonIgnore]
         public string HumanMarkerIconOrDefault =>
             string.IsNullOrWhiteSpace(HumanMarkerIcon) ? "person_walking" : HumanMarkerIcon;
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string CollarTrackColorModeOrDefault =>
+            CollarColorModeOrDefault(CollarTrackColorMode, "black");
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string CollarMarkerColorModeOrDefault =>
+            CollarColorModeOrDefault(CollarMarkerColorMode, "area-black-outline");
+
+        private static string CollarColorModeOrDefault(string? value, string defaultValue) =>
+            value is "black" or "contrast" or "area" or "area-dots" or "area-black-outline" or "area-white-outline" or "black-white-outline" or "area-cased" or "black-cased" ? value : defaultValue;
 
         // Warnzentrum-Regelkonfiguration (keyed by WarningEntry.Source)
         public Dictionary<string, WarningRuleConfig> WarningRules { get; set; } = new();
@@ -180,6 +193,8 @@ namespace Einsatzueberwachung.Domain.Models
             // Karten-Marker-Defaults
             CollarMarkerIcon = "paw";
             HumanMarkerIcon = "person_walking";
+            CollarTrackColorMode = "black";
+            CollarMarkerColorMode = "area-black-outline";
 
             // Divera 24/7 Defaults
             DiveraEnabled = false;

--- a/src/Einsatzueberwachung.Domain/Services/PdfExportService.Export.cs
+++ b/src/Einsatzueberwachung.Domain/Services/PdfExportService.Export.cs
@@ -145,7 +145,7 @@ namespace Einsatzueberwachung.Domain.Services
                     var imageBytes = await _mapRenderer!.RenderTrackMapAsync(
                         track.Points,
                         track.SearchAreaCoordinates?.Count >= 3 ? track.SearchAreaCoordinates : null,
-                        track.Color,
+                        "#000000",
                         track.SearchAreaColor,
                         800, 450);
 

--- a/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Pages/EinsatzKarte.razor.cs
@@ -120,6 +120,8 @@ public partial class EinsatzKarte
     // Karten-Marker Konfiguration (aus AppSettings geladen)
     private string _collarMarkerIcon = "paw";
     private string _humanMarkerIcon = "phone";
+    private string _collarTrackColorMode = "area";
+    private string _collarMarkerColorMode = "area";
 
     private string _coordInputMode = "click"; // "click", "latlong", "utm" — auch von KartePunkteTab über @bind synchronisiert
     private bool _clickToPlaceActive = false;
@@ -175,6 +177,8 @@ public partial class EinsatzKarte
         _mapZoom = settings.MapDefaultZoom;
         _collarMarkerIcon = settings.CollarMarkerIconOrDefault;
         _humanMarkerIcon = settings.HumanMarkerIconOrDefault;
+        _collarTrackColorMode = settings.CollarTrackColorModeOrDefault;
+        _collarMarkerColorMode = settings.CollarMarkerColorModeOrDefault;
 
         // Wenn Einsatzort-Adresse vorhanden, versuche zu geocoden
         if (!string.IsNullOrWhiteSpace(EinsatzService.CurrentEinsatz.MapAddress))
@@ -242,7 +246,12 @@ public partial class EinsatzKarte
 
                 // Collar-Tracking initialisieren
                 await JSRuntime.InvokeVoidAsync("CollarTracking.initialize", "einsatzMap", _dotNetReference);
-                await JSRuntime.InvokeVoidAsync("CollarTracking.setOptions", new { collarIcon = _collarMarkerIcon });
+                await JSRuntime.InvokeVoidAsync("CollarTracking.setOptions", new
+                {
+                    collarIcon = _collarMarkerIcon,
+                    trackColorMode = _collarTrackColorMode,
+                    markerColorMode = _collarMarkerColorMode
+                });
 
                 // Handy-GPS Layer initialisieren
                 await JSRuntime.InvokeVoidAsync("PhoneTracking.initialize", "einsatzMap");

--- a/src/Einsatzueberwachung.Server/Components/Pages/Einstellungen.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/Einstellungen.razor
@@ -238,6 +238,8 @@
                                 <option value="dog">Hund-Kopf</option>
                                 <option value="bone">Knochen</option>
                                 <option value="dot">Farbiger Punkt</option>
+                                <option value="crosshairs">Fadenkreuz (präzise Position)</option>
+                                <option value="location-arrow">Richtungspfeil (Bewegungsposition)</option>
                             </InputSelect>
                             <span class="cfg-help">Symbol für die aktuelle Position eines GPS-Halsbands auf der Karte.</span>
                         </div>
@@ -251,6 +253,32 @@
                                 <option value="dot">Farbiger Punkt</option>
                             </InputSelect>
                             <span class="cfg-help">Symbol für die aktuelle Handy-GPS-Position eines Teams auf der Karte.</span>
+                        </div>
+                    </div>
+                    <div class="cfg-grid cfg-grid-2 mt-2">
+                        <div class="cfg-field">
+                            <label class="cfg-label">Farbe: Hundepfad</label>
+                            <InputSelect class="cfg-input" @bind-Value="_appSettings.CollarTrackColorMode">
+                                <option value="area">Suchgebiet-Farbe</option>
+                                <option value="black">Schwarz</option>
+                                <option value="area-dots">Schwarz mit Suchgebiets-Punkten</option>
+                                <option value="contrast">Kontrastfarbe</option>
+                                <option value="area-cased">Suchgebietsfarbe mit schwarzem Rand</option>
+                                <option value="black-cased">Schwarz mit weißem Rand</option>
+                            </InputSelect>
+                            <span class="cfg-help">Farbe des GPS-Pfads des Hundes auf Live-Karten.</span>
+                        </div>
+                        <div class="cfg-field">
+                            <label class="cfg-label">Farbe: Live-Icon Hund</label>
+                            <InputSelect class="cfg-input" @bind-Value="_appSettings.CollarMarkerColorMode">
+                                <option value="area-black-outline">Suchgebiet-Farbe mit schwarzem Rand</option>
+                                <option value="area-white-outline">Suchgebiet-Farbe mit weißem Rand</option>
+                                <option value="black-white-outline">Schwarz mit weißem Rand</option>
+                                <option value="area">Suchgebiet-Farbe</option>
+                                <option value="black">Schwarz</option>
+                                <option value="contrast">Kontrastfarbe</option>
+                            </InputSelect>
+                            <span class="cfg-help">Farbe des GPS-Halsband-Symbols auf Live-Karten.</span>
                         </div>
                     </div>
                 </div>

--- a/src/Einsatzueberwachung.Server/Components/Pages/Lage.razor.cs
+++ b/src/Einsatzueberwachung.Server/Components/Pages/Lage.razor.cs
@@ -31,6 +31,8 @@ public partial class Lage : IAsyncDisposable
     // Karten-Marker Konfiguration (aus AppSettings geladen)
     private string _collarMarkerIcon = "paw";
     private string _humanMarkerIcon = "phone";
+    private string _collarTrackColorMode = "area";
+    private string _collarMarkerColorMode = "area";
 
     private string _einsatzTitle = "—";
     private string _vermisstName = "—";
@@ -52,6 +54,8 @@ public partial class Lage : IAsyncDisposable
         _mapZoom = settings.MapDefaultZoom;
         _collarMarkerIcon = settings.CollarMarkerIconOrDefault;
         _humanMarkerIcon = settings.HumanMarkerIconOrDefault;
+        _collarTrackColorMode = settings.CollarTrackColorModeOrDefault;
+        _collarMarkerColorMode = settings.CollarMarkerColorModeOrDefault;
 
         if (einsatz.ElwPosition.HasValue)
         {
@@ -130,7 +134,12 @@ public partial class Lage : IAsyncDisposable
 
             // Live-Tracking aktivieren
             await JSRuntime.InvokeVoidAsync("CollarTracking.initialize", "lageMap", _dotNetReference);
-            await JSRuntime.InvokeVoidAsync("CollarTracking.setOptions", new { collarIcon = _collarMarkerIcon });
+            await JSRuntime.InvokeVoidAsync("CollarTracking.setOptions", new
+            {
+                collarIcon = _collarMarkerIcon,
+                trackColorMode = _collarTrackColorMode,
+                markerColorMode = _collarMarkerColorMode
+            });
             await JSRuntime.InvokeVoidAsync("CollarTracking.toggleVisibility", "lageMap", true);
             await JSRuntime.InvokeVoidAsync("PhoneTracking.initialize", "lageMap");
             await JSRuntime.InvokeVoidAsync("PhoneTracking.setOptions", new { humanIcon = _humanMarkerIcon });

--- a/src/Einsatzueberwachung.Server/Components/Pages/TeamMobile.razor
+++ b/src/Einsatzueberwachung.Server/Components/Pages/TeamMobile.razor
@@ -311,7 +311,9 @@ else
             await JS.InvokeVoidAsync("teamMobileMap.setOptions", new
             {
                 collarIcon = mapSettings.CollarMarkerIconOrDefault,
-                humanIcon  = mapSettings.HumanMarkerIconOrDefault
+                humanIcon  = mapSettings.HumanMarkerIconOrDefault,
+                trackColorMode = mapSettings.CollarTrackColorModeOrDefault,
+                markerColorMode = mapSettings.CollarMarkerColorModeOrDefault
             });
         }
         catch { /* tolerant — Icons bleiben auf Standard-Wert */ }

--- a/src/Einsatzueberwachung.Server/wwwroot/js/collar-tracking.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/js/collar-tracking.js
@@ -37,10 +37,59 @@ window.CollarTracking = {
 
     // Konfiguriertes Halsband-Marker-Symbol ("paw" | "dog" | "bone" | "dot")
     _collarIcon: 'paw',
+    _trackColorMode: 'black',
+    _markerColorMode: 'area-black-outline',
+
+    _resolveColor: function (areaColor, mode) {
+        if (mode === 'black' || mode === 'black-white-outline') return '#000000';
+        if (mode !== 'contrast' || !/^#[0-9a-f]{6}$/i.test(areaColor)) return areaColor;
+
+        const red = parseInt(areaColor.slice(1, 3), 16);
+        const green = parseInt(areaColor.slice(3, 5), 16);
+        const blue = parseInt(areaColor.slice(5, 7), 16);
+        return `#${(255 - red).toString(16).padStart(2, '0')}${(255 - green).toString(16).padStart(2, '0')}${(255 - blue).toString(16).padStart(2, '0')}`;
+    },
+
+    _resolveTrackColor: function (areaColor) {
+        return this._trackColorMode === 'area-dots' || this._trackColorMode === 'black-cased'
+            ? '#000000'
+            : this._resolveColor(areaColor, this._trackColorMode);
+    },
+
+    _createTrackOutline: function (positions, opacity) {
+        if (this._trackColorMode !== 'area-cased' && this._trackColorMode !== 'black-cased') return null;
+
+        return L.polyline(positions, {
+            color: this._trackColorMode === 'area-cased' ? '#000000' : '#ffffff',
+            weight: 7,
+            opacity: opacity,
+            lineCap: 'round',
+            lineJoin: 'round',
+            interactive: false
+        });
+    },
+
+    _createTrackDotOverlay: function (positions, areaColor, opacity) {
+        if (this._trackColorMode !== 'area-dots') return null;
+
+        return L.polyline(positions, {
+            color: this._resolveColor(areaColor, 'area'),
+            weight: 6,
+            opacity: opacity,
+            dashArray: '1 17',
+            lineCap: 'round',
+            interactive: false
+        });
+    },
 
     // Gibt Font-Awesome-Icon-HTML basierend auf Konfiguration und Farbe zurück
     _getCollarIconHtml: function (color) {
-        const style = `font-size:24px;color:${color};filter:drop-shadow(0 1px 3px rgba(0,0,0,0.55));display:block;line-height:1;`;
+        const outline = this._markerColorMode === 'area-black-outline'
+            ? '-webkit-text-stroke:1.5px #000;paint-order:stroke fill;'
+            : this._markerColorMode === 'area-white-outline' || this._markerColorMode === 'black-white-outline'
+                ? '-webkit-text-stroke:1.5px #fff;paint-order:stroke fill;'
+                : '';
+        const style = `font-size:24px;color:${color};${outline}filter:drop-shadow(0 1px 3px rgba(0,0,0,0.55));display:block;line-height:1;`;
         switch (this._collarIcon) {
             case 'paw':
                 return `<i class="fa-solid fa-paw" style="${style}"></i>`;
@@ -48,6 +97,10 @@ window.CollarTracking = {
                 return `<i class="fa-solid fa-dog" style="${style}"></i>`;
             case 'bone':
                 return `<i class="fa-solid fa-bone" style="${style}"></i>`;
+            case 'crosshairs':
+                return `<i class="fa-solid fa-crosshairs" style="${style}"></i>`;
+            case 'location-arrow':
+                return `<i class="fa-solid fa-location-arrow" style="${style}"></i>`;
             case 'dot':
             default:
                 return `<i class="fa-solid fa-location-dot" style="${style}"></i>`;
@@ -57,6 +110,8 @@ window.CollarTracking = {
     // Setzt Darstellungsoptionen (wird direkt nach initialize() aufgerufen)
     setOptions: function (opts) {
         if (opts && opts.collarIcon) this._collarIcon = opts.collarIcon;
+        if (opts && ['area', 'black', 'contrast', 'area-dots', 'area-cased', 'black-cased'].includes(opts.trackColorMode)) this._trackColorMode = opts.trackColorMode;
+        if (opts && ['area', 'black', 'contrast', 'area-black-outline', 'area-white-outline', 'black-white-outline'].includes(opts.markerColorMode)) this._markerColorMode = opts.markerColorMode;
     },
 
     // Erstellt das divIcon für einen Halsband-Marker (konfiguriertes Symbol, optional mit OOB-Pulsring)
@@ -134,41 +189,51 @@ window.CollarTracking = {
             this._tracks[collarId] = {
                 positions: [],
                 polyline: null,
+                outlineOverlay: null,
+                dotOverlay: null,
                 marker: null,
-                color: color || this._colors[this._colorIndex % this._colors.length]
+                baseColor: color || this._colors[this._colorIndex % this._colors.length]
             };
             if (!color) this._colorIndex++;
         }
 
         // Farbe aktualisieren falls explizit übergeben und geändert
-        if (color && this._tracks[collarId].color !== color) {
-            this._setTrackColor(mapData, collarId, color);
+        if (color && this._tracks[collarId].baseColor !== color) {
+            this._setTrackColors(mapData, collarId, color);
         }
         // Label aktualisieren falls mitgeliefert
         if (dogLabel) this._tracks[collarId].dogLabel = dogLabel;
 
         const track = this._tracks[collarId];
+        const trackColor = this._resolveTrackColor(track.baseColor);
+        const markerColor = this._resolveColor(track.baseColor, this._markerColorMode);
         track.positions.push([lat, lng]);
 
         // Polyline aktualisieren oder erstellen
         if (track.polyline && mapData.trackingLayer.hasLayer(track.polyline)) {
             track.polyline.addLatLng([lat, lng]);
+            if (track.outlineOverlay) track.outlineOverlay.addLatLng([lat, lng]);
+            if (track.dotOverlay) track.dotOverlay.addLatLng([lat, lng]);
         } else {
             // Polyline neu erstellen (auch wenn alte Referenz existiert aber nicht mehr auf der Karte ist)
+            track.outlineOverlay = this._createTrackOutline(track.positions, 0.9);
+            if (track.outlineOverlay) track.outlineOverlay.addTo(mapData.trackingLayer);
             track.polyline = L.polyline(track.positions, {
-                color: track.color,
+                color: trackColor,
                 weight: 3,
                 opacity: 0.8,
                 dashArray: null
             });
             track.polyline.addTo(mapData.trackingLayer);
+            track.dotOverlay = this._createTrackDotOverlay(track.positions, track.baseColor, 0.8);
+            if (track.dotOverlay) track.dotOverlay.addTo(mapData.trackingLayer);
         }
 
         // Aktuellen Positions-Marker aktualisieren
         if (track.marker && mapData.trackingLayer.hasLayer(track.marker)) {
             track.marker.setLatLng([lat, lng]);
         } else {
-            const icon = this._createCollarIcon(track.color, track._oobActive);
+            const icon = this._createCollarIcon(markerColor, track._oobActive);
             track.marker = L.marker([lat, lng], { icon: icon })
                 .bindPopup(`<strong>${track.dogLabel || collarId}</strong><br><small>Halsband: ${collarId}</small><br><small>UTM: ${latLngToUtm(lat, lng)}</small><br><small>${new Date(timestamp).toLocaleTimeString('de-DE')}</small>`);
             track.marker.addTo(mapData.trackingLayer);
@@ -198,33 +263,41 @@ window.CollarTracking = {
             this._tracks[collarId] = {
                 positions: [],
                 polyline: null,
+                outlineOverlay: null,
+                dotOverlay: null,
                 marker: null,
-                color: color || this._colors[this._colorIndex % this._colors.length],
+                baseColor: color || this._colors[this._colorIndex % this._colors.length],
                 dogLabel: dogLabel || collarId
             };
             if (!color) this._colorIndex++;
         } else if (color) {
-            this._tracks[collarId].color = color;
+            this._tracks[collarId].baseColor = color;
         }
         if (dogLabel) this._tracks[collarId].dogLabel = dogLabel;
 
         const track = this._tracks[collarId];
+        const trackColor = this._resolveTrackColor(track.baseColor);
+        const markerColor = this._resolveColor(track.baseColor, this._markerColorMode);
         const positions = locations.map(loc => [loc.latitude, loc.longitude]);
         track.positions = positions;
 
         if (positions.length > 0) {
             // Polyline zeichnen
+            track.outlineOverlay = this._createTrackOutline(positions, 0.9);
+            if (track.outlineOverlay) track.outlineOverlay.addTo(mapData.trackingLayer);
             track.polyline = L.polyline(positions, {
-                color: track.color,
+                color: trackColor,
                 weight: 3,
                 opacity: 0.8
             });
             track.polyline.addTo(mapData.trackingLayer);
+            track.dotOverlay = this._createTrackDotOverlay(positions, track.baseColor, 0.8);
+            if (track.dotOverlay) track.dotOverlay.addTo(mapData.trackingLayer);
 
             // Marker an letzter Position
             const lastPos = positions[positions.length - 1];
             const lastLoc = locations[locations.length - 1];
-            const icon = this._createCollarIcon(track.color, false);
+            const icon = this._createCollarIcon(markerColor, false);
             track.marker = L.marker(lastPos, { icon: icon })
                 .bindPopup(`<strong>${track.dogLabel || collarId}</strong><br><small>Halsband: ${collarId}</small><br><small>UTM: ${latLngToUtm(lastPos[0], lastPos[1])}</small><br><small>${new Date(lastLoc.timestamp).toLocaleTimeString('de-DE')}</small>`);
             track.marker.addTo(mapData.trackingLayer);
@@ -240,7 +313,7 @@ window.CollarTracking = {
         if (!track || !track.marker) return;
 
         // Marker-Icon durch pulsierende Variante ersetzen
-        const icon = this._createCollarIcon(track.color, true);
+        const icon = this._createCollarIcon(this._resolveColor(track.baseColor, this._markerColorMode), true);
         track.marker.setIcon(icon);
         track._oobActive = true;
 
@@ -261,7 +334,7 @@ window.CollarTracking = {
             track._oobTimeout = null;
         }
 
-        const icon = this._createCollarIcon(track.color, false);
+        const icon = this._createCollarIcon(this._resolveColor(track.baseColor, this._markerColorMode), false);
         track.marker.setIcon(icon);
         track._oobActive = false;
     },
@@ -281,6 +354,8 @@ window.CollarTracking = {
         const track = this._tracks[collarId];
         if (track) {
             if (track.polyline) mapData.trackingLayer.removeLayer(track.polyline);
+            if (track.outlineOverlay) mapData.trackingLayer.removeLayer(track.outlineOverlay);
+            if (track.dotOverlay) mapData.trackingLayer.removeLayer(track.dotOverlay);
             if (track.marker) mapData.trackingLayer.removeLayer(track.marker);
             delete this._tracks[collarId];
         }
@@ -297,19 +372,27 @@ window.CollarTracking = {
     },
 
     // Farbe eines bestehenden Tracks ändern (Polyline + Marker neu zeichnen)
-    _setTrackColor: function (mapData, collarId, newColor) {
+    _setTrackColors: function (mapData, collarId, newColor) {
         const track = this._tracks[collarId];
         if (!track) return;
-        track.color = newColor;
+        track.baseColor = newColor;
+        const trackColor = this._resolveTrackColor(newColor);
+        const markerColor = this._resolveColor(newColor, this._markerColorMode);
 
         // Polyline-Farbe aktualisieren
         if (track.polyline && mapData.trackingLayer.hasLayer(track.polyline)) {
-            track.polyline.setStyle({ color: newColor });
+            track.polyline.setStyle({ color: trackColor });
+        }
+        if (track.outlineOverlay && mapData.trackingLayer.hasLayer(track.outlineOverlay)) {
+            track.outlineOverlay.setStyle({ color: this._trackColorMode === 'area-cased' ? '#000000' : '#ffffff' });
+        }
+        if (track.dotOverlay && mapData.trackingLayer.hasLayer(track.dotOverlay)) {
+            track.dotOverlay.setStyle({ color: this._resolveColor(newColor, 'area') });
         }
 
         // Marker-Icon mit neuer Farbe ersetzen
         if (track.marker && mapData.trackingLayer.hasLayer(track.marker)) {
-            const icon = this._createCollarIcon(newColor, track._oobActive);
+            const icon = this._createCollarIcon(markerColor, track._oobActive);
             track.marker.setIcon(icon);
         }
     },
@@ -344,13 +427,17 @@ window.CollarTracking = {
 
         const positions = points.map(p => [p.latitude, p.longitude]);
 
+        const outlineOverlay = this._createTrackOutline(positions, isHumanTrack ? 0.7 : 0.6);
+        if (outlineOverlay) outlineOverlay.addTo(mapData.trackingLayer);
         const polyline = L.polyline(positions, {
-            color: color,
+            color: this._resolveTrackColor(color),
             weight: isHumanTrack ? 3 : 4,
             opacity: isHumanTrack ? 0.7 : 0.5,
             dashArray: isHumanTrack ? '3 8' : '6 5'
         });
         polyline.addTo(mapData.trackingLayer);
+        const dotOverlay = isHumanTrack ? null : this._createTrackDotOverlay(positions, color, 0.5);
+        if (dotOverlay) dotOverlay.addTo(mapData.trackingLayer);
 
         // Klick auf Linie → Blazor-Callback um GPS-Tab zu öffnen und Snapshot aufzuklappen
         polyline.on('click', () => {
@@ -366,7 +453,7 @@ window.CollarTracking = {
         // Start-Marker (kleines Dreieck)
         const startIcon = L.divIcon({
             html: `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-                <polygon points="7,1 13,13 1,13" fill="${color}" stroke="white" stroke-width="1.5" opacity="0.7"/>
+                <polygon points="7,1 13,13 1,13" fill="${this._resolveColor(color, this._trackColorMode)}" stroke="white" stroke-width="1.5" opacity="0.7"/>
             </svg>`,
             iconSize: [14, 14], iconAnchor: [7, 7], className: 'collar-completed-icon'
         });
@@ -378,7 +465,7 @@ window.CollarTracking = {
         const lastPos = positions[positions.length - 1];
         const endIcon = L.divIcon({
             html: `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-                <rect x="1" y="1" width="12" height="12" fill="${color}" stroke="white" stroke-width="1.5" opacity="0.7"/>
+                <rect x="1" y="1" width="12" height="12" fill="${this._resolveColor(color, this._trackColorMode)}" stroke="white" stroke-width="1.5" opacity="0.7"/>
             </svg>`,
             iconSize: [14, 14], iconAnchor: [7, 7], className: 'collar-completed-icon'
         });
@@ -388,6 +475,8 @@ window.CollarTracking = {
 
         this._completedTracks[snapshotId] = {
             polyline: polyline,
+            outlineOverlay: outlineOverlay,
+            dotOverlay: dotOverlay,
             startMarker: startMarker,
             endMarker: endMarker,
             visible: true
@@ -403,7 +492,7 @@ window.CollarTracking = {
         if (!ct) return;
 
         ct.visible = visible;
-        [ct.polyline, ct.startMarker, ct.endMarker].forEach(layer => {
+        [ct.outlineOverlay, ct.polyline, ct.dotOverlay, ct.startMarker, ct.endMarker].forEach(layer => {
             if (!layer) return;
             if (visible) {
                 if (!mapData.trackingLayer.hasLayer(layer)) mapData.trackingLayer.addLayer(layer);
@@ -428,7 +517,7 @@ window.CollarTracking = {
     _removeCompletedTrackLayers: function (mapData, snapshotId) {
         const ct = this._completedTracks[snapshotId];
         if (!ct) return;
-        [ct.polyline, ct.startMarker, ct.endMarker].forEach(layer => {
+        [ct.outlineOverlay, ct.polyline, ct.dotOverlay, ct.startMarker, ct.endMarker].forEach(layer => {
             if (layer && mapData.trackingLayer.hasLayer(layer))
                 mapData.trackingLayer.removeLayer(layer);
         });

--- a/src/Einsatzueberwachung.Server/wwwroot/js/team-mobile-map.js
+++ b/src/Einsatzueberwachung.Server/wwwroot/js/team-mobile-map.js
@@ -3,6 +3,8 @@ window.teamMobileMap = (function () {
     let polygonLayer = null;
     let dogMarker = null;
     let trackLine = null;
+    let trackOutline = null;
+    let trackDots = null;
     let userMarker = null;
     let userTrackLine = null;
     // Abgeschlossene Track-Episoden früherer Suchläufe (historisch, persistent auf dem Server)
@@ -12,21 +14,75 @@ window.teamMobileMap = (function () {
     let _collarIcon = 'paw';
     let _humanIcon = 'phone';
 
-    // Farbe des aktuellen Suchgebiets – wird von renderSearchArea gesetzt und für Hund-Marker und Track übernommen
+    // Farbe des aktuellen Suchgebiets – wird von renderSearchArea gesetzt
     let _areaColor = '#dc3545';
+    let _trackColorMode = 'black';
+    let _markerColorMode = 'area-black-outline';
 
     function setOptions(opts) {
         if (opts && opts.collarIcon) _collarIcon = opts.collarIcon;
         if (opts && opts.humanIcon)  _humanIcon  = opts.humanIcon;
+        if (opts && ['area', 'black', 'contrast', 'area-dots', 'area-cased', 'black-cased'].includes(opts.trackColorMode)) _trackColorMode = opts.trackColorMode;
+        if (opts && ['area', 'black', 'contrast', 'area-black-outline', 'area-white-outline', 'black-white-outline'].includes(opts.markerColorMode)) _markerColorMode = opts.markerColorMode;
+    }
+
+    function _resolveColor(mode) {
+        if (mode === 'black' || mode === 'black-white-outline') return '#000000';
+        if (mode !== 'contrast' || !/^#[0-9a-f]{6}$/i.test(_areaColor)) return _areaColor;
+        const red = parseInt(_areaColor.slice(1, 3), 16);
+        const green = parseInt(_areaColor.slice(3, 5), 16);
+        const blue = parseInt(_areaColor.slice(5, 7), 16);
+        return `#${(255 - red).toString(16).padStart(2, '0')}${(255 - green).toString(16).padStart(2, '0')}${(255 - blue).toString(16).padStart(2, '0')}`;
+    }
+
+    function _resolveTrackColor() {
+        return _trackColorMode === 'area-dots' || _trackColorMode === 'black-cased' ? '#000000' : _resolveColor(_trackColorMode);
+    }
+
+    function _createTrackOutline(points, opacity) {
+        if (_trackColorMode !== 'area-cased' && _trackColorMode !== 'black-cased') return null;
+
+        return L.polyline(points, {
+            color: _trackColorMode === 'area-cased' ? '#000000' : '#ffffff',
+            weight: 7,
+            opacity,
+            lineCap: 'round',
+            lineJoin: 'round',
+            interactive: false
+        }).addTo(map);
+    }
+
+    function _createTrackDots(points, opacity) {
+        if (_trackColorMode !== 'area-dots') return null;
+
+        return L.polyline(points, {
+            color: _areaColor,
+            weight: 6,
+            opacity: opacity,
+            dashArray: '1 17',
+            lineCap: 'round',
+            interactive: false
+        }).addTo(map);
     }
 
     function _getCollarIconClass() {
         switch (_collarIcon) {
             case 'dog':  return 'fa-dog';
             case 'bone': return 'fa-bone';
+            case 'crosshairs': return 'fa-crosshairs';
+            case 'location-arrow': return 'fa-location-arrow';
             case 'dot':  return 'fa-location-dot';
             default:     return 'fa-paw'; // paw
         }
+    }
+
+    function _getCollarIconStyle() {
+        const outline = _markerColorMode === 'area-black-outline'
+            ? '-webkit-text-stroke:1.5px #000;paint-order:stroke fill;'
+            : _markerColorMode === 'area-white-outline' || _markerColorMode === 'black-white-outline'
+                ? '-webkit-text-stroke:1.5px #fff;paint-order:stroke fill;'
+                : '';
+        return `font-size:26px;color:${_resolveColor(_markerColorMode)};${outline}filter:drop-shadow(0 1px 3px rgba(0,0,0,0.55));display:block;line-height:1;`;
     }
 
     function _getHumanIconClass() {
@@ -76,7 +132,7 @@ window.teamMobileMap = (function () {
         if (!dogMarker) {
             const icon = L.divIcon({
                 className: 'team-mobile-dog-marker',
-                html: `<i class="fa-solid ${_getCollarIconClass()}" style="font-size:26px;color:${_areaColor};filter:drop-shadow(0 1px 3px rgba(0,0,0,0.55));display:block;line-height:1;"></i>`,
+                html: `<i class="fa-solid ${_getCollarIconClass()}" style="${_getCollarIconStyle()}"></i>`,
                 iconSize: [26, 26],
                 iconAnchor: [13, 13]
             });
@@ -90,20 +146,29 @@ window.teamMobileMap = (function () {
     function setTrack(points) {
         if (!map) return;
         if (trackLine) { map.removeLayer(trackLine); trackLine = null; }
+        if (trackOutline) { map.removeLayer(trackOutline); trackOutline = null; }
+        if (trackDots) { map.removeLayer(trackDots); trackDots = null; }
         if (!points || points.length < 2) return;
-        trackLine = L.polyline(points.map(p => [p.lat, p.lng]), {
-            color: _areaColor,
+        const trackPoints = points.map(p => [p.lat, p.lng]);
+        trackOutline = _createTrackOutline(trackPoints, 0.8);
+        trackLine = L.polyline(trackPoints, {
+            color: _resolveTrackColor(),
             weight: 3,
             opacity: 0.7
         }).addTo(map);
+        trackDots = _createTrackDots(trackPoints, 0.7);
     }
 
     function appendTrackPoint(lat, lng) {
         if (!map) return;
         if (!trackLine) {
-            trackLine = L.polyline([[lat, lng]], { color: _areaColor, weight: 3, opacity: 0.7 }).addTo(map);
+            trackOutline = _createTrackOutline([[lat, lng]], 0.8);
+            trackLine = L.polyline([[lat, lng]], { color: _resolveTrackColor(), weight: 3, opacity: 0.7 }).addTo(map);
+            trackDots = _createTrackDots([[lat, lng]], 0.7);
         } else {
             trackLine.addLatLng([lat, lng]);
+            if (trackOutline) trackOutline.addLatLng([lat, lng]);
+            if (trackDots) trackDots.addLatLng([lat, lng]);
         }
     }
 
@@ -149,13 +214,17 @@ window.teamMobileMap = (function () {
         const polyline = L.polyline(
             points.map(p => [p.lat, p.lng]),
             {
-                color: color || '#888888',
+                color: isHumanTrack ? (color || '#888888') : _resolveTrackColor(),
                 weight: 3,
                 opacity: 0.55,
                 dashArray: isHumanTrack ? '4 9' : null
             }
         ).addTo(map);
         historicalTracks.push(polyline);
+        if (!isHumanTrack) {
+            const dotOverlay = _createTrackDots(points.map(p => [p.lat, p.lng]), 0.55);
+            if (dotOverlay) historicalTracks.push(dotOverlay);
+        }
     }
 
     function loadUserTrack(points) {
@@ -204,6 +273,7 @@ window.teamMobileMap = (function () {
         polygonLayer = null;
         dogMarker = null;
         trackLine = null;
+        trackDots = null;
         userMarker = null;
         userTrackLine = null;
     }

--- a/src/Einsatzueberwachung.Tests/AppSettingsColorModeTests.cs
+++ b/src/Einsatzueberwachung.Tests/AppSettingsColorModeTests.cs
@@ -1,0 +1,37 @@
+using Einsatzueberwachung.Domain.Models;
+
+namespace Einsatzueberwachung.Tests;
+
+public class AppSettingsColorModeTests
+{
+    [Fact]
+    public void CollarColorModes_DefaultAndInvalidValuesUseConfiguredDefaults()
+    {
+        var settings = new AppSettings();
+
+        Assert.Equal("black", settings.CollarTrackColorModeOrDefault);
+        Assert.Equal("area-black-outline", settings.CollarMarkerColorModeOrDefault);
+
+        settings.CollarTrackColorMode = "invalid";
+        settings.CollarMarkerColorMode = "contrast";
+
+        Assert.Equal("black", settings.CollarTrackColorModeOrDefault);
+        Assert.Equal("contrast", settings.CollarMarkerColorModeOrDefault);
+
+        settings.CollarMarkerColorMode = "area-white-outline";
+        Assert.Equal("area-white-outline", settings.CollarMarkerColorModeOrDefault);
+
+        settings.CollarMarkerColorMode = "black-white-outline";
+        Assert.Equal("black-white-outline", settings.CollarMarkerColorModeOrDefault);
+
+        settings.CollarTrackColorMode = "area-dots";
+
+        Assert.Equal("area-dots", settings.CollarTrackColorModeOrDefault);
+
+        settings.CollarTrackColorMode = "area-cased";
+        Assert.Equal("area-cased", settings.CollarTrackColorModeOrDefault);
+
+        settings.CollarTrackColorMode = "black-cased";
+        Assert.Equal("black-cased", settings.CollarTrackColorModeOrDefault);
+    }
+}

--- a/src/Einsatzueberwachung.Tests/PdfExportSmokeTests.cs
+++ b/src/Einsatzueberwachung.Tests/PdfExportSmokeTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Einsatzueberwachung.Domain.Interfaces;
 using Einsatzueberwachung.Domain.Models;
 using Einsatzueberwachung.Domain.Models.Enums;
 using Einsatzueberwachung.Domain.Services;
@@ -115,5 +116,58 @@ public class PdfExportSmokeTests
         Assert.Equal("%PDF-", Encoding.ASCII.GetString(bytes, 0, 5));
         var tail = Encoding.ASCII.GetString(bytes, Math.Max(0, bytes.Length - 16), Math.Min(16, bytes.Length));
         Assert.Contains("%%EOF", tail);
+    }
+
+    [Fact]
+    public async Task ExportEinsatzToPdfBytesAsync_RendertTracksSchwarz()
+    {
+        var mapRenderer = new RecordingMapRenderer();
+        var service = new PdfExportService(mapRenderer: mapRenderer);
+        var einsatz = MinimalEinsatz();
+        einsatz.TrackSnapshots = new List<TeamTrackSnapshot>
+        {
+            new()
+            {
+                Color = "#e63946",
+                Points = new List<TrackPoint>
+                {
+                    new() { Latitude = 49.0, Longitude = 8.0 },
+                    new() { Latitude = 49.1, Longitude = 8.1 }
+                }
+            }
+        };
+
+        await service.ExportEinsatzToPdfBytesAsync(einsatz, MinimalTeams(), MinimalNotes(), includeTracks: true);
+
+        Assert.Equal("#000000", mapRenderer.TrackColor);
+    }
+
+    private sealed class RecordingMapRenderer : IStaticMapRenderer
+    {
+        public string? TrackColor { get; private set; }
+
+        public Task<byte[]?> RenderTrackMapAsync(List<TrackPoint> trackPoints,
+            List<(double Latitude, double Longitude)>? searchAreaCoords, string trackColor,
+            string? areaColor, int width = 800, int height = 450)
+        {
+            TrackColor = trackColor;
+            return Task.FromResult<byte[]?>(null);
+        }
+
+        public Task<byte[]?> RenderCombinedTrackMapAsync(List<TeamTrackSnapshot> tracks,
+            (double Latitude, double Longitude)? elwPosition, int width = 1200, int height = 780)
+            => Task.FromResult<byte[]?>(null);
+
+        public Task<byte[]?> RenderSearchAreaMapAsync(List<SearchArea> searchAreas,
+            (double Latitude, double Longitude)? elwPosition, MapTileType tileType = MapTileType.Streets,
+            int width = 1500, int height = 1060)
+            => Task.FromResult<byte[]?>(null);
+
+        public Task<byte[]?> RenderSearchAreaMapAsync(List<SearchArea> searchAreas,
+            (double Latitude, double Longitude)? elwPosition, MapPrintOptions options,
+            List<MapMarker>? markers = null, List<TeamTrackSnapshot>? gpsTracks = null,
+            Dictionary<string, List<TeamPhoneLocation>>? phoneTrackHistories = null,
+            List<Team>? teams = null, int width = 1500, int height = 1060)
+            => Task.FromResult<byte[]?>(null);
     }
 }


### PR DESCRIPTION
Es gibt jetzt mehrere Optionen, wie sich die Farbe des Icons und des Pfades verhält.


<img width="638" height="298" alt="image" src="https://github.com/user-attachments/assets/03684470-cef9-4b57-9857-779e80e48f52" />
<img width="672" height="342" alt="image" src="https://github.com/user-attachments/assets/958bc538-ec3e-48fa-b594-96942b6b3b6b" />
<img width="413" height="285" alt="image" src="https://github.com/user-attachments/assets/40c4fa4d-40ec-4745-9d4e-e63c532aaa55" />
<img width="526" height="421" alt="image" src="https://github.com/user-attachments/assets/8ec47ef4-3c2c-4d5f-9315-89bbb59a2a94" />
<img width="277" height="195" alt="image" src="https://github.com/user-attachments/assets/46af029a-600d-4135-a133-3beafc86b1e1" />
